### PR TITLE
Move handling of no Behandlendeenhet found to OPLPSService

### DIFF
--- a/src/main/kotlin/no/nav/syfo/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/KafkaModule.kt
@@ -2,16 +2,19 @@ package no.nav.syfo
 
 import io.ktor.application.Application
 import kotlinx.coroutines.launch
+import no.nav.syfo.client.enhet.BehandlendeEnhetClient
 import no.nav.syfo.kafka.setupKafka
 import no.nav.syfo.oversikthendelse.OversikthendelseProducer
 import no.nav.syfo.personoppgave.oppfolgingsplanlps.OppfolgingsplanLPSService
 
 fun Application.kafkaModule(
     vaultSecrets: VaultSecrets,
+    behandlendeEnhetClient: BehandlendeEnhetClient,
     oversikthendelseProducer: OversikthendelseProducer
 ) {
     val oppfolgingsplanLPSService = OppfolgingsplanLPSService(
         database,
+        behandlendeEnhetClient,
         oversikthendelseProducer
     )
     var toggleProcessing = false

--- a/src/main/kotlin/no/nav/syfo/MainApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/MainApplication.kt
@@ -54,16 +54,14 @@ fun main() {
         )
         val producerProperties = kafkaProducerConfig(env, vaultSecrets)
         val oversikthendelseRecordProducer = KafkaProducer<String, KOversikthendelse>(producerProperties)
-        val oversikthendelseProducer = OversikthendelseProducer(
-            oversikthendelseRecordProducer,
-            behandlendeEnhetClient
-        )
+        val oversikthendelseProducer = OversikthendelseProducer(oversikthendelseRecordProducer)
 
         module {
             databaseModule()
             serverModule()
             kafkaModule(
                 vaultSecrets,
+                behandlendeEnhetClient,
                 oversikthendelseProducer
             )
         }

--- a/src/test/kotlin/no/nav/syfo/personoppgave/oppfolgingsplanlps/OppfolgingsplanLPSServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personoppgave/oppfolgingsplanlps/OppfolgingsplanLPSServiceSpek.kt
@@ -30,12 +30,10 @@ object OppfolgingsplanLPSServiceSpek : Spek({
 
         val behandlendeEnhetClient = mockk<BehandlendeEnhetClient>()
         val mockProducer: KafkaProducer<String, KOversikthendelse> = mockk(relaxed = true)
-        val oversikthendelseProducer = OversikthendelseProducer(
-            mockProducer,
-            behandlendeEnhetClient
-        )
+        val oversikthendelseProducer = OversikthendelseProducer(mockProducer)
         val oppfolgingsplanLPSService = OppfolgingsplanLPSService(
             database,
+            behandlendeEnhetClient,
             oversikthendelseProducer
         )
 


### PR DESCRIPTION
OppfolgingsplanLPSService should handle the case where no BehandlendeEnhet is found for a Fodselsnummer. This handling is therefor moved there from OversikthendelseProducer. A check to se if Oversikthendelse is actually sent before PersonOppgave is updated with oversikthendelse_tidspunkt to conform that the Oversikthendelse is sent.