### PR TITLE
Use personOppgaveUUID as Kafka message key

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/OversikthendelseProducer.kt
@@ -18,6 +18,7 @@ class OversikthendelseProducer(
     private val producer: KafkaProducer<String, KOversikthendelse>
 ) {
     fun sendOversikthendelse(
+        key: UUID,
         fnr: Fodselsnummer,
         behandlendeEnhet: BehandlendeEnhet,
         oversikthendelseType: OversikthendelseType,
@@ -29,13 +30,13 @@ class OversikthendelseProducer(
             enhetId = behandlendeEnhet.enhetId,
             tidspunkt = LocalDateTime.now()
         )
-        producer.send(producerRecord(kOversikthendelse))
+        producer.send(producerRecord(key, kOversikthendelse))
     }
 }
 
-private fun producerRecord(oversikthendelse: KOversikthendelse) =
+private fun producerRecord(key: UUID, oversikthendelse: KOversikthendelse) =
     SyfoProducerRecord(
         topic = OVERSIKTHENDELSE_TOPIC,
-        key = UUID.randomUUID().toString(),
+        key = key.toString(),
         value = oversikthendelse
     )

--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/KOversikthendelseRetry.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/KOversikthendelseRetry.kt
@@ -12,7 +12,8 @@ data class KOversikthendelseRetry(
     val retriedCount: Int,
     val fnr: String,
     val oversikthendelseType: String,
-    val personOppgaveId: Int
+    val personOppgaveId: Int,
+    val personOppgaveUUID: String
 )
 
 fun KOversikthendelseRetry.hasExceededRetryLimit(): Boolean {

--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/OversikthendelseRetryProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/OversikthendelseRetryProducer.kt
@@ -21,6 +21,7 @@ class OversikthendelseRetryProducer(
         fnr: Fodselsnummer,
         oversikthendelseType: OversikthendelseType,
         personOppgaveId: Int,
+        personOppgaveUUID: UUID,
         callId: String = ""
     ) {
         val now = LocalDateTime.now()
@@ -30,7 +31,8 @@ class OversikthendelseRetryProducer(
             retriedCount = 0,
             fnr = fnr.value,
             oversikthendelseType = oversikthendelseType.name,
-            personOppgaveId = personOppgaveId
+            personOppgaveId = personOppgaveId,
+            personOppgaveUUID = personOppgaveUUID.toString()
         )
         producer.send(producerRecord(firstKOversikthendelseRetry))
         log.warn(
@@ -83,7 +85,7 @@ class OversikthendelseRetryProducer(
     private fun producerRecord(oversikthendelseRetry: KOversikthendelseRetry) =
         SyfoProducerRecord(
             topic = OVERSIKTHENDELSE_RETRY_TOPIC,
-            key = UUID.randomUUID().toString(),
+            key = oversikthendelseRetry.personOppgaveUUID,
             value = oversikthendelseRetry
         )
 

--- a/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/OversikthendelseRetryService.kt
+++ b/src/main/kotlin/no/nav/syfo/oversikthendelse/retry/OversikthendelseRetryService.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.oversikthendelse.domain.OversikthendelseType
 import no.nav.syfo.personoppgave.getPersonOppgaveList
 import no.nav.syfo.personoppgave.updatePersonOppgaveOversikthendelse
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class OversikthendelseRetryService(
     private val behandlendeEnhetClient: BehandlendeEnhetClient,
@@ -64,6 +65,7 @@ class OversikthendelseRetryService(
                     personOppgave.oversikthendelseTidspunkt == null
             }?.let {
                 oversikthendelseProducer.sendOversikthendelse(
+                    UUID.fromString(kOversikthendelseRetry.personOppgaveUUID),
                     fodselsnummer,
                     behandlendeEnhet,
                     OversikthendelseType.valueOf(kOversikthendelseRetry.oversikthendelseType),

--- a/src/main/kotlin/no/nav/syfo/personoppgave/PersonOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/PersonOppgaveService.kt
@@ -49,6 +49,7 @@ class PersonOppgaveService(
 
         if (isOnePersonOppgaveUbehandlet) {
             oversikthendelseProducer.sendOversikthendelse(
+                personoppgave.uuid,
                 personFnr,
                 behandlendeEnhet,
                 OversikthendelseType.OPPFOLGINGSPLANLPS_BISTAND_BEHANDLET,

--- a/src/test/kotlin/no/nav/syfo/oversikthendelse/retry/KafkaOversikthendelseRetrySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oversikthendelse/retry/KafkaOversikthendelseRetrySpek.kt
@@ -266,17 +266,18 @@ object KafkaOversikthendelseRetrySpek : Spek({
             it("should resend KOversikthendelseRetry to topic when it has not exceeded retry limit and is not ready for retry") {
                 val kOppfolgingsplanLPSNAV = generateKOppfolgingsplanLPSNAV(ARBEIDSTAKER_FNR)
                 val personOppgaveType = PersonOppgaveType.OPPFOLGINGSPLANLPS
-                val createdPersonOppgaveId = database.connection.createPersonOppgave(
+                val createdPersonOppgaveIdPair = database.connection.createPersonOppgave(
                     kOppfolgingsplanLPSNAV,
                     personOppgaveType
-                ).first
+                )
 
                 val kOversikthendelseRetry = generateKOversikthendelseRetry.copy(
                     fnr = ARBEIDSTAKER_FNR.value,
                     created = LocalDateTime.now(),
                     retryTime = LocalDateTime.now().plusHours(1),
                     retriedCount = 0,
-                    personOppgaveId = createdPersonOppgaveId
+                    personOppgaveId = createdPersonOppgaveIdPair.first,
+                    personOppgaveUUID = createdPersonOppgaveIdPair.second.toString()
                 )
                 val kOversiktHendelseRetryJson = objectMapper.writeValueAsString(kOversikthendelseRetry)
                 val oversiktHendelseRetryRecord = ConsumerRecord(

--- a/src/test/kotlin/no/nav/syfo/personoppgave/oppfolgingsplanlps/OppfolgingsplanLPSServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personoppgave/oppfolgingsplanlps/OppfolgingsplanLPSServiceSpek.kt
@@ -166,7 +166,7 @@ object OppfolgingsplanLPSServiceSpek : Spek({
 
                 it("should create a new PPersonOppgave with correct type and send KOversikthendelseRetry when behovForBistand=true and behandlendeEnhet=null") {
                     val mockOversikthendelseRetryProducer = mockk<OversikthendelseRetryProducer>()
-                    justRun { mockOversikthendelseRetryProducer.sendFirstOversikthendelseRetry(any(), any(), any()) }
+                    justRun { mockOversikthendelseRetryProducer.sendFirstOversikthendelseRetry(any(), any(), any(), any()) }
 
                     val oppfolgingsplanLPSServiceWithMockOversikthendelseRetryProcuer = OppfolgingsplanLPSService(
                         database,
@@ -197,7 +197,8 @@ object OppfolgingsplanLPSServiceSpek : Spek({
                         mockOversikthendelseRetryProducer.sendFirstOversikthendelseRetry(
                             fnr = fodselsnummer,
                             oversikthendelseType = OversikthendelseType.OPPFOLGINGSPLANLPS_BISTAND_MOTTATT,
-                            personOppgaveId = personOppgave.id
+                            personOppgaveId = personOppgave.id,
+                            personOppgaveUUID = personOppgave.uuid
                         )
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testutil/generator/KOversikthendelseRetryGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generator/KOversikthendelseRetryGenerator.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.oversikthendelse.domain.OversikthendelseType
 import no.nav.syfo.oversikthendelse.retry.KOversikthendelseRetry
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
 import java.time.LocalDateTime
+import java.util.*
 
 val generateKOversikthendelseRetry =
     KOversikthendelseRetry(
@@ -13,4 +14,5 @@ val generateKOversikthendelseRetry =
         fnr = ARBEIDSTAKER_FNR.value,
         oversikthendelseType = OversikthendelseType.OPPFOLGINGSPLANLPS_BISTAND_MOTTATT.name,
         personOppgaveId = 1,
+        personOppgaveUUID = UUID.randomUUID().toString(),
     ).copy()


### PR DESCRIPTION
Use personOppgaveUUID as key for produced messages to both topic for Oversikthendelse and OversikthendelseRetry. This will ensure that messages with the same key will be sent to the same partition and hence it can be guaranteed that messages with the same key is processed in order.