### PR TITLE
Update Tilgangskontroll for person

### DIFF
--- a/src/test/kotlin/no/nav/syfo/testutil/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/VeilederTilgangskontrollMock.kt
@@ -8,9 +8,10 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import no.nav.syfo.api.installContentNegotiation
 import no.nav.syfo.client.veiledertilgang.Tilgang
-import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_V2_PERSON_PATH
+import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_PATH
 import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
 import no.nav.syfo.testutil.getRandomPort
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
 class VeilederTilgangskontrollMock {
     private val port = getRandomPort()
@@ -42,11 +43,12 @@ class VeilederTilgangskontrollMock {
         ) {
             installContentNegotiation()
             routing {
-                get("$TILGANGSKONTROLL_V2_PERSON_PATH/${ARBEIDSTAKER_FNR.value}") {
-                    call.respond(tilgangTrue)
-                }
-                get(TILGANGSKONTROLL_V2_PERSON_PATH) {
-                    call.respond(HttpStatusCode.Forbidden, tilgangFalse)
+                get(TILGANGSKONTROLL_PERSON_PATH) {
+                    if (call.request.headers[NAV_PERSONIDENT_HEADER] == ARBEIDSTAKER_FNR.value) {
+                        call.respond(tilgangTrue)
+                    } else {
+                        call.respond(HttpStatusCode.Forbidden, tilgangFalse)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Update to newest person-tilgangskontroll in Syfo-tilgangskontroll. This endpoint requires PersonIdent as a header instead of as a parameter in the URL.