### PR TITLE
add missing namespace to metric

### DIFF
--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -28,7 +28,7 @@ val COUNT_PERSON_OPPGAVE_OPPFOLGINGSPLANLPS_NO_BEHOVFORBISTAND: Counter =
         .register(METRICS_REGISTRY)
 
 const val OVERSIKTHENDELSE_OPPFOLGINGSPLANLPS_BISTAND_MOTTATT_SENT =
-    "oversikthendelse_oppfolgingsplanlps_bistand_mottatt_sent_count"
+    "${METRICS_NS}_oversikthendelse_oppfolgingsplanlps_bistand_mottatt_sent_count"
 val COUNT_OVERSIKTHENDELSE_OPPFOLGINGSPLANLPS_BISTAND_MOTTATT_SENT: Counter =
     Counter.builder(OVERSIKTHENDELSE_OPPFOLGINGSPLANLPS_BISTAND_MOTTATT_SENT)
         .description("Counts the number of Oversikthendelse with OversikthendelseType OPPFOLGINGSPLANLPS_BISTAND_MOTTATT created from a KOppfolgingsplanLPS")


### PR DESCRIPTION
Telleren fungerer ikke i https://grafana.nais.io/d/_TFcBRWGz/isyfo-teknisk?orgId=1. Ser ut som namespace forsvant fra en metric i https://github.com/navikt/ispersonoppgave/pull/35