### PR TITLE
Mark personoppgave as ready to publish and ubehandlet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotesvar/DialogmotesvarService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotesvar/DialogmotesvarService.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.dialogmotesvar.domain.*
 import no.nav.syfo.metric.COUNT_DIALOGMOTESVAR_OPPGAVE_UPDATED
 import no.nav.syfo.personoppgave.*
 import no.nav.syfo.personoppgave.domain.*
+import no.nav.syfo.util.toLocalDateTimeOslo
 import java.sql.Connection
 import java.util.*
 
@@ -23,7 +24,13 @@ fun processDialogmotesvar(
     } else {
         val oppgave = pPersonOppgave.toPersonOppgave()
         if (dialogmotesvar happenedAfter oppgave) {
-            connection.updateDialogmotesvarOppgaveSetUbehandlet(dialogmotesvar)
+            val updatedOppgave = oppgave.copy(
+                behandletTidspunkt = null,
+                behandletVeilederIdent = null,
+                sistEndret = dialogmotesvar.svarReceivedAt.toLocalDateTimeOslo(),
+                publish = true,
+            )
+            connection.updatePersonoppgave(updatedOppgave)
             COUNT_DIALOGMOTESVAR_OPPGAVE_UPDATED.increment()
         }
     }

--- a/src/main/kotlin/no/nav/syfo/personoppgave/domain/PPersonOppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/domain/PPersonOppgave.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.personoppgave.domain
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.*
 
 data class PPersonOppgave(
@@ -16,7 +17,9 @@ data class PPersonOppgave(
     val behandletTidspunkt: LocalDateTime?,
     val behandletVeilederIdent: String?,
     val opprettet: LocalDateTime,
-    val sistEndret: LocalDateTime
+    val sistEndret: LocalDateTime,
+    val publish: Boolean,
+    val publishedAt: OffsetDateTime?, // TODO: is this needed?
 )
 
 fun PPersonOppgave.toPersonOppgave(): PersonOppgave {
@@ -31,6 +34,8 @@ fun PPersonOppgave.toPersonOppgave(): PersonOppgave {
         behandletTidspunkt = this.behandletTidspunkt,
         behandletVeilederIdent = this.behandletVeilederIdent,
         opprettet = this.opprettet,
-        sistEndret = this.sistEndret
+        sistEndret = this.sistEndret,
+        publish = this.publish,
+        publishedAt = this.publishedAt,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/personoppgave/domain/PersonOppgave.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/domain/PersonOppgave.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.personoppgave.api.PersonOppgaveVeileder
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.*
 
 data class PersonOppgave(
@@ -18,6 +19,8 @@ data class PersonOppgave(
     val behandletVeilederIdent: String?,
     val opprettet: LocalDateTime,
     val sistEndret: LocalDateTime, // Referansetidspunkt til når hendelsen som sist endret oppgaven skjedde
+    val publish: Boolean,
+    val publishedAt: OffsetDateTime?,
 )
 
 fun PersonOppgave.toPersonOppgaveVeileder(): PersonOppgaveVeileder {

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -12,3 +12,6 @@ fun convertNullable(timestamp: Timestamp?): LocalDateTime? =
 fun OffsetDateTime.toLocalDateTimeOslo(): LocalDateTime = this.atZoneSameInstant(
     ZoneId.of("Europe/Oslo")
 ).toLocalDateTime()
+
+fun LocalDateTime.toOffsetDateTimeUTC(): OffsetDateTime =
+    this.atZone(ZoneId.of("Europe/Oslo")).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()

--- a/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/DialogmoteStatusendringServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/DialogmoteStatusendringServiceSpek.kt
@@ -4,7 +4,7 @@ import io.mockk.*
 import no.nav.syfo.dialogmotestatusendring.domain.DialogmoteStatusendringType
 import no.nav.syfo.personoppgave.*
 import no.nav.syfo.testutil.generateDialogmotestatusendring
-import no.nav.syfo.testutil.generatePersonoppgave
+import no.nav.syfo.testutil.generatePPersonoppgave
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.sql.Connection
@@ -38,7 +38,7 @@ object DialogmoteStatusendringServiceSpek : Spek({
                         dialogmoteUuid,
                         HAPPENS_NOW,
                     )
-                val personoppgave = generatePersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
+                val personoppgave = generatePPersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
                 every { connection.getPersonOppgaveByReferanseUuid(dialogmoteUuid) } returns personoppgave
                 every {
                     connection.behandleOppgave(statusendring)
@@ -60,7 +60,7 @@ object DialogmoteStatusendringServiceSpek : Spek({
                         dialogmoteUuid,
                         HAPPENS_NOW,
                     )
-                val personoppgave = generatePersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
+                val personoppgave = generatePPersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
                 every { connection.getPersonOppgaveByReferanseUuid(dialogmoteUuid) } returns personoppgave
                 every {
                     connection.behandleOppgave(statusendring)
@@ -78,7 +78,7 @@ object DialogmoteStatusendringServiceSpek : Spek({
             it("Finish personoppgave when a dialogmote is cancelled") {
                 val statusendring =
                     generateDialogmotestatusendring(DialogmoteStatusendringType.AVLYST, dialogmoteUuid, HAPPENS_NOW)
-                val personoppgave = generatePersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
+                val personoppgave = generatePPersonoppgave(dialogmoteUuid, ONE_DAY_AGO.toLocalDateTime())
                 every { connection.getPersonOppgaveByReferanseUuid(dialogmoteUuid) } returns personoppgave
                 every {
                     connection.behandleOppgave(statusendring)
@@ -114,7 +114,7 @@ object DialogmoteStatusendringServiceSpek : Spek({
             it("Do nothing if a dialogmøte created happened before personoppgave was sist endret") {
                 val statusendring =
                     generateDialogmotestatusendring(DialogmoteStatusendringType.INNKALT, dialogmoteUuid, ONE_DAY_AGO)
-                val personoppgave = generatePersonoppgave(dialogmoteUuid, HAPPENS_NOW.toLocalDateTime())
+                val personoppgave = generatePPersonoppgave(dialogmoteUuid, HAPPENS_NOW.toLocalDateTime())
                 every { connection.getPersonOppgaveByReferanseUuid(dialogmoteUuid) } returns personoppgave
 
                 processDialogmoteStatusendring(connection, statusendring)
@@ -131,7 +131,7 @@ object DialogmoteStatusendringServiceSpek : Spek({
                         dialogmoteUuid,
                         ONE_DAY_AGO
                     )
-                val personoppgave = generatePersonoppgave(dialogmoteUuid, HAPPENS_NOW.toLocalDateTime())
+                val personoppgave = generatePPersonoppgave(dialogmoteUuid, HAPPENS_NOW.toLocalDateTime())
                 every { connection.getPersonOppgaveByReferanseUuid(dialogmoteUuid) } returns personoppgave
 
                 processDialogmoteStatusendring(connection, statusendring)

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
@@ -77,6 +77,7 @@ fun Connection.createPersonOppgave(
             it.setString(5, type.name)
             it.setTimestamp(6, now)
             it.setTimestamp(7, now)
+            it.setBoolean(8, false)
             it.executeQuery().toList { getInt("id") }
         }
 

--- a/src/test/kotlin/no/nav/syfo/testutil/personoppgaveGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/personoppgaveGenerator.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.testutil
+
+import no.nav.syfo.personoppgave.domain.PersonOppgave
+import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import java.time.LocalDateTime
+import java.util.*
+
+fun generatePersonoppgave() = PersonOppgave(
+    id = 1,
+    uuid = UUID.randomUUID(),
+    referanseUuid = UUID.randomUUID(),
+    personIdent = UserConstants.ARBEIDSTAKER_FNR,
+    virksomhetsnummer = UserConstants.VIRKSOMHETSNUMMER,
+    type = PersonOppgaveType.DIALOGMOTESVAR,
+    oversikthendelseTidspunkt = null,
+    behandletTidspunkt = null,
+    behandletVeilederIdent = null,
+    opprettet = LocalDateTime.now(),
+    sistEndret = LocalDateTime.now(),
+    publish = false,
+    publishedAt = null,
+)

--- a/src/test/kotlin/no/nav/syfo/testutil/ppersonoppgaveGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ppersonoppgaveGenerator.kt
@@ -5,9 +5,9 @@ import no.nav.syfo.personoppgave.domain.PersonOppgaveType
 import java.time.LocalDateTime
 import java.util.*
 
-fun generatePersonoppgave(
-    moteuuid: UUID,
-    sistEndret: LocalDateTime
+fun generatePPersonoppgave(
+    moteuuid: UUID = UUID.randomUUID(),
+    sistEndret: LocalDateTime = LocalDateTime.now(),
 ) =
     PPersonOppgave(
         id = 1,
@@ -20,5 +20,7 @@ fun generatePersonoppgave(
         behandletTidspunkt = null,
         behandletVeilederIdent = null,
         opprettet = LocalDateTime.now(),
-        sistEndret = sistEndret
+        sistEndret = sistEndret,
+        publish = false,
+        publishedAt = null,
     )


### PR DESCRIPTION
Changed the updatequery to accept a personoppgave instead of møtesvar, to keep a more clean separation between the db and domain layers. Should also be more reusable.

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>