### PR TITLE
Enable publishing of oppgavehendelser on dialogmøtesvar

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -85,6 +85,6 @@ spec:
     - name: TOGGLE_KAFKA_DIALOGMOTESVAR_CONSUMER_ENABLED
       value: "true"
     - name: PUBLISH_OPPGAVEHENDELSER_ENABLED
-      value: "false"
+      value: "true"
     - name: OUTDATED_DIALOGMOTESVAR_CUTOFF
       value: "2022-04-01"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -85,6 +85,6 @@ spec:
     - name: TOGGLE_KAFKA_DIALOGMOTESVAR_CONSUMER_ENABLED
       value: "true"
     - name: PUBLISH_OPPGAVEHENDELSER_ENABLED
-      value: "false"
+      value: "true"
     - name: OUTDATED_DIALOGMOTESVAR_CUTOFF
       value: "2022-04-01"

--- a/src/main/kotlin/no/nav/syfo/personoppgavehendelse/PersonoppgavehendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgavehendelse/PersonoppgavehendelseProducer.kt
@@ -1,14 +1,12 @@
 package no.nav.syfo.personoppgavehendelse
 
 import no.nav.syfo.domain.PersonIdent
-import no.nav.syfo.personoppgave.domain.PersonOppgave
 import no.nav.syfo.personoppgavehendelse.domain.KPersonoppgavehendelse
 import no.nav.syfo.personoppgavehendelse.domain.PersonoppgavehendelseType
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.*
 import java.util.*
 
 private val log: Logger = LoggerFactory.getLogger("no.nav.syfo.personoppgavehendelse")
@@ -36,35 +34,6 @@ class PersonoppgavehendelseProducer(
                 kPersonoppgavehendelse,
             )
             producer.send(record).get()
-        } catch (e: Exception) {
-            log.error(
-                "Exception was thrown when attempting to send KPersonoppgavehendelse with id {}: ${e.message}",
-                personoppgaveId,
-            )
-            throw e
-        }
-    }
-
-    fun sendPersonoppgavehendelse( // TODO: Merge the two functions in this class
-        hendelsetype: PersonoppgavehendelseType,
-        personOppgave: PersonOppgave,
-    ): OffsetDateTime {
-        val kPersonoppgavehendelse = KPersonoppgavehendelse(
-            personOppgave.personIdent.value,
-            hendelsetype.name
-        )
-
-        val personoppgaveId = personOppgave.uuid
-
-        try {
-            log.info("Sending personoppgavehendelse of type $hendelsetype, personoppgaveId: $personoppgaveId")
-            val record = ProducerRecord(
-                PERSONOPPGAVEHENDELSE_TOPIC,
-                personoppgaveId.toString(),
-                kPersonoppgavehendelse,
-            )
-            producer.send(record).get()
-            return Instant.ofEpochMilli(record.timestamp()).atOffset(ZoneOffset.UTC)
         } catch (e: Exception) {
             log.error(
                 "Exception was thrown when attempting to send KPersonoppgavehendelse with id {}: ${e.message}",

--- a/src/main/kotlin/no/nav/syfo/personoppgavehendelse/PublishPersonoppgavehendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgavehendelse/PublishPersonoppgavehendelseService.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.personoppgave.*
 import no.nav.syfo.personoppgave.domain.*
 import org.slf4j.LoggerFactory
 import java.sql.Connection
+import java.time.OffsetDateTime
 
 class PublishPersonoppgavehendelseService(
     private val personoppgavehendelseProducer: PersonoppgavehendelseProducer,
@@ -29,13 +30,14 @@ class PublishPersonoppgavehendelseService(
 
         if (isNewest(connection, personOppgave)) {
             val hendelsetype = personOppgave.toHendelseType()
-            val publishedAt = personoppgavehendelseProducer.sendPersonoppgavehendelse(
+            personoppgavehendelseProducer.sendPersonoppgavehendelse(
                 hendelsetype = hendelsetype,
-                personOppgave = personOppgave,
+                personIdent = personOppgave.personIdent,
+                personoppgaveId = personOppgave.uuid,
             )
             updatedPersonOppgave = personOppgave.copy(
                 publish = false,
-                publishedAt = publishedAt,
+                publishedAt = OffsetDateTime.now(),
             )
         } else {
             log.info("Do not publish PersonOppgave with uuid ${personOppgave.uuid} because oppgave from later meeting exists")


### PR DESCRIPTION
Dette gjelder publisering av endringer på oppgaver av typen dialogmøtesvar, disse publiseres fra en cronjobb basert på oppgaven sin publishstatus. Likevel så vil vi kun publisere hvis oppgaven er den nyeste dialogmøteoppgaven, og lukker oppgaven hvis vi ikke rakk å publisere endringen på den før en nyere kom inn. 

T.O den andre typen personoppgave i denne appen er innkomne LPS planer hvor AT/AG ber om bistand, disse personoppgaveendringene legges på kafka synkront. 

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>