### PR TITLE
Behandle all dialogmoteoppgaver

### DIFF
--- a/src/main/resources/db/migration/V3_5__behandle_dialogmoteoppgaver_before_cutoff_publish.sql
+++ b/src/main/resources/db/migration/V3_5__behandle_dialogmoteoppgaver_before_cutoff_publish.sql
@@ -1,0 +1,9 @@
+UPDATE person_oppgave
+SET behandlet_veileder_ident = 'X00000',
+    behandlet_tidspunkt = now(),
+    sist_endret = now(),
+    publish = true
+WHERE behandlet_veileder_ident IS null
+  AND behandlet_tidspunkt IS null
+  AND TYPE = 'DIALOGMOTESVAR';
+


### PR DESCRIPTION
Da kan vi starte med blanke ark, så slipper vi å forklare for veilederne hvorfor det plutselig er mange oppgaver. Det er kanskje noen av oppgavenene som gjelder passerte møter.

Co-authored-by: June Henriksen <june.henriksen2@nav.no>