### PR TITLE
Close oppgave where behandler corrected their response

### DIFF
--- a/src/main/resources/db/migration/V3_9__close_oppgaver_where_behandler_corrected_answer.sql
+++ b/src/main/resources/db/migration/V3_9__close_oppgaver_where_behandler_corrected_answer.sql
@@ -1,0 +1,6 @@
+UPDATE person_oppgave
+SET behandlet_tidspunkt = now(),
+    behandlet_veileder_ident = 'X000000',
+    publish = true,
+    published_at = null
+WHERE referanse_uuid IN ('a2810e8d-4b25-473d-b80f-1c2c9d54eea6');


### PR DESCRIPTION
This oppgave is not possible to complete because behandler changed their response from 'NYTT_TID_STED' to 'KOMMER'. This causes us to create an oppgave for the first response, but then hide the "behandle" button because the latest answer is 'KOMMER'. https://jira.adeo.no/browse/FAGSYSTEM-253198