### PR TITLE
Close oppgave where behandler corrected their response

### DIFF
--- a/src/main/resources/db/migration/V4_1__close_oppgaver_where_behandler_corrected_answer_2.sql
+++ b/src/main/resources/db/migration/V4_1__close_oppgaver_where_behandler_corrected_answer_2.sql
@@ -1,0 +1,6 @@
+UPDATE person_oppgave
+SET behandlet_tidspunkt = now(),
+    behandlet_veileder_ident = 'X000000',
+    publish = true,
+    published_at = null
+WHERE referanse_uuid IN ('960e67a5-4d81-4dee-a055-39a9cee2aa86');


### PR DESCRIPTION
Try this again with correct uuid, last commit was wrong.
2f221d953fe999b721e8c849d69ada3e3d37cda4 used oppgave uuid instead of referanse_uuid.
This oppgave is not possible to complete because behandler changed their response from 'NYTT_TID_STED' to 'KOMMER'.
This causes us to create an oppgave for the first response, but then hide the "behandle" button because the latest answer is 'KOMMER'. https://jira.adeo.no/browse/FAGSYSTEM-253198