### PR TITLE
Add identer-api for PDL

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -86,3 +86,7 @@ spec:
       value: "2022-04-01"
     - name: TOGGLE_KAFKA_IDENTHENDELSE_CONSUMER_ENABLED
       value: "true"
+    - name: PDL_CLIENT_ID
+      value: "dev-fss.pdl.pdl-api"
+    - name: PDL_URL
+      value: "https://pdl-api.dev-fss-pub.nais.io/graphql"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -86,3 +86,7 @@ spec:
       value: "2022-04-01"
     - name: TOGGLE_KAFKA_IDENTHENDELSE_CONSUMER_ENABLED
       value: "false"
+    - name: PDL_CLIENT_ID
+      value: "prod-fss.pdl.pdl-api"
+    - name: PDL_URL
+      value: "https://pdl-api.prod-fss-pub.nais.io/graphql"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -17,6 +17,9 @@ data class Environment(
     val ispersonoppgaveDbUsername: String = getEnvVar("NAIS_DATABASE_ISPERSONOPPGAVE_ISPERSONOPPGAVE_DB_USERNAME"),
     val ispersonoppgaveDbPassword: String = getEnvVar("NAIS_DATABASE_ISPERSONOPPGAVE_ISPERSONOPPGAVE_DB_PASSWORD"),
 
+    val pdlUrl: String = getEnvVar("PDL_URL"),
+    val pdlClientId: String = getEnvVar("PDL_CLIENT_ID"),
+
     val serviceuserUsername: String = getEnvVar("SERVICEUSER_USERNAME"),
     val serviceuserPassword: String = getEnvVar("SERVICEUSER_PASSWORD"),
 

--- a/src/main/kotlin/no/nav/syfo/MainApplication.kt
+++ b/src/main/kotlin/no/nav/syfo/MainApplication.kt
@@ -7,6 +7,8 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import no.nav.syfo.api.apiModule
 import no.nav.syfo.api.authentication.getWellKnown
+import no.nav.syfo.client.azuread.v2.AzureAdV2Client
+import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.cronjob.cronjobModule
 import no.nav.syfo.database.database
 import no.nav.syfo.database.databaseModule
@@ -38,6 +40,18 @@ fun main() {
         wellKnownUrl = environment.azureAppWellKnownUrl,
     )
 
+    val azureAdV2Client = AzureAdV2Client(
+        azureAppClientId = environment.azureAppClientId,
+        azureAppClientSecret = environment.azureAppClientSecret,
+        azureTokenEndpoint = environment.azureTokenEndpoint,
+    )
+
+    val pdlClient = PdlClient(
+        azureAdV2Client = azureAdV2Client,
+        pdlClientId = environment.pdlClientId,
+        pdlUrl = environment.pdlUrl,
+    )
+
     val applicationEngineEnvironment = applicationEngineEnvironment {
         log = LoggerFactory.getLogger("ktor.application")
         config = HoconApplicationConfig(ConfigFactory.load())
@@ -51,6 +65,7 @@ fun main() {
             )
             apiModule(
                 applicationState = applicationState,
+                azureAdV2Client = azureAdV2Client,
                 database = database,
                 environment = environment,
                 personoppgavehendelseProducer = personoppgavehendelseProducer,

--- a/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.personoppgavehendelse.PersonoppgavehendelseProducer
 
 fun Application.apiModule(
     applicationState: ApplicationState,
+    azureAdV2Client: AzureAdV2Client,
     database: DatabaseInterface,
     environment: Environment,
     personoppgavehendelseProducer: PersonoppgavehendelseProducer,
@@ -37,11 +38,6 @@ fun Application.apiModule(
     val personOppgaveService = PersonOppgaveService(
         database = database,
         personoppgavehendelseProducer = personoppgavehendelseProducer,
-    )
-    val azureAdV2Client = AzureAdV2Client(
-        azureAppClientId = environment.azureAppClientId,
-        azureAppClientSecret = environment.azureAppClientSecret,
-        azureTokenEndpoint = environment.azureTokenEndpoint,
     )
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
         azureAdV2Client = azureAdV2Client,

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -1,0 +1,84 @@
+package no.nav.syfo.client.pdl
+
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import no.nav.syfo.client.azuread.v2.AzureAdV2Client
+import no.nav.syfo.client.httpClientDefault
+import no.nav.syfo.client.pdl.domain.*
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.util.*
+import org.slf4j.LoggerFactory
+
+class PdlClient(
+    private val azureAdV2Client: AzureAdV2Client,
+    private val pdlClientId: String,
+    private val pdlUrl: String,
+) {
+    private val httpClient = httpClientDefault()
+
+    suspend fun getPdlIdenter(
+        personIdent: PersonIdent,
+        callId: String? = null,
+    ): PdlHentIdenter? {
+        val token = azureAdV2Client.getSystemToken(pdlClientId)
+            ?: throw RuntimeException("Failed to send PdlHentIdenterRequest to PDL: No token was found")
+
+        val query = getPdlQuery(
+            queryFilePath = "/pdl/hentIdenter.graphql",
+        )
+
+        val request = PdlHentIdenterRequest(
+            query = query,
+            variables = PdlHentIdenterRequestVariables(
+                ident = personIdent.value,
+                historikk = true,
+                grupper = listOf(
+                    IdentType.FOLKEREGISTERIDENT,
+                ),
+            ),
+        )
+
+        val response: HttpResponse = httpClient.post(pdlUrl) {
+            header(HttpHeaders.Authorization, bearerHeader(token.accessToken))
+            header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            header(TEMA_HEADER, ALLE_TEMA_HEADERVERDI)
+            header(NAV_CALL_ID_HEADER, callId)
+            header(IDENTER_HEADER, IDENTER_HEADER)
+            setBody(request)
+        }
+
+        when (response.status) {
+            HttpStatusCode.OK -> {
+                val pdlIdenterResponse = response.body<PdlIdenterResponse>()
+                return if (!pdlIdenterResponse.errors.isNullOrEmpty()) {
+                    COUNT_CALL_PDL_IDENTER_FAIL.increment()
+                    pdlIdenterResponse.errors.forEach {
+                        logger.error("Error while requesting IdentList from PersonDataLosningen: ${it.errorMessage()}")
+                    }
+                    null
+                } else {
+                    COUNT_CALL_PDL_IDENTER_SUCCESS.increment()
+                    pdlIdenterResponse.data
+                }
+            }
+            else -> {
+                COUNT_CALL_PDL_IDENTER_FAIL.increment()
+                logger.error("Request to get IdentList with url: $pdlClientId failed with reponse code ${response.status.value}")
+                return null
+            }
+        }
+    }
+
+    private fun getPdlQuery(queryFilePath: String): String {
+        return this::class.java.getResource(queryFilePath)!!
+            .readText()
+            .replace("[\n\r]", "")
+    }
+
+    companion object {
+        const val IDENTER_HEADER = "identer"
+        private val logger = LoggerFactory.getLogger(PdlClient::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.client.pdl
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.metric.METRICS_NS
+import no.nav.syfo.metric.METRICS_REGISTRY
+
+const val CALL_PDL_IDENTER_BASE = "${METRICS_NS}_call_pdl_identer"
+const val CALL_PDL_IDENTER_SUCCESS = "${CALL_PDL_IDENTER_BASE}_success_count"
+const val CALL_PDL_IDENTER_FAIL = "${CALL_PDL_IDENTER_BASE}_fail_count"
+
+val COUNT_CALL_PDL_IDENTER_SUCCESS: Counter = Counter.builder(CALL_PDL_IDENTER_SUCCESS)
+    .description("Counts the number of successful calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PDL_IDENTER_FAIL: Counter = Counter.builder(CALL_PDL_IDENTER_FAIL)
+    .description("Counts the number of failed calls to persondatalosning - identer")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlError.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlError.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.client.pdl.domain
+
+data class PdlError(
+    val message: String,
+    val locations: List<PdlErrorLocation>,
+    val path: List<String>?,
+    val extensions: PdlErrorExtension,
+)
+
+data class PdlErrorLocation(
+    val line: Int?,
+    val column: Int?,
+)
+
+data class PdlErrorExtension(
+    val code: String?,
+    val classification: String,
+)
+
+fun PdlError.errorMessage(): String {
+    return "${this.message} with code: ${extensions.code} and classification: ${extensions.classification}"
+}

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlHentIdenterRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlHentIdenterRequest.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.client.pdl.domain
+
+data class PdlHentIdenterRequest(
+    val query: String,
+    val variables: PdlHentIdenterRequestVariables,
+)
+
+data class PdlHentIdenterRequestVariables(
+    val ident: String,
+    val historikk: Boolean,
+    val grupper: List<IdentType>,
+)

--- a/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/domain/PdlIdenterResponse.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.client.pdl.domain
+
+data class PdlIdenterResponse(
+    val data: PdlHentIdenter?,
+    val errors: List<PdlError>?
+)
+
+data class PdlHentIdenter(
+    val hentIdenter: PdlIdenter?,
+)
+
+data class PdlIdenter(
+    val identer: List<PdlIdent>,
+) {
+    val aktivIdent: String? = identer.firstOrNull {
+        it.gruppe == IdentType.FOLKEREGISTERIDENT && !it.historisk
+    }?.ident
+}
+
+data class PdlIdent(
+    val ident: String,
+    val historisk: Boolean,
+    val gruppe: IdentType,
+)
+
+enum class IdentType {
+    FOLKEREGISTERIDENT,
+    AKTORID,
+    NPID,
+}

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -15,6 +15,8 @@ const val NAV_CONSUMER_ID = "Nav-Consumer-Id"
 
 const val NAV_CALL_ID = "Nav-Call-Id"
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
+const val TEMA_HEADER = "Tema"
+const val ALLE_TEMA_HEADERVERDI = "GEN"
 
 fun PipelineContext<out Unit, ApplicationCall>.getCallId(): String {
     return this.call.getCallId()

--- a/src/main/resources/pdl/hentIdenter.graphql
+++ b/src/main/resources/pdl/hentIdenter.graphql
@@ -1,0 +1,9 @@
+query($ident: ID!, $grupper: [IdentGruppe!], $historikk: Boolean = false){
+	hentIdenter(ident: $ident, grupper:$grupper, historikk:$historikk) {
+		identer {
+			ident,
+			historisk,
+			gruppe
+		}
+	}
+}

--- a/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/ExternalMockEnvironment.kt
@@ -14,18 +14,21 @@ class ExternalMockEnvironment(
         withSchemaRegistry = withSchemaRegistry,
     )
 
-    val azureAdV2Mock = AzureAdV2Mock()
-    val tilgangskontrollMock = VeilederTilgangskontrollMock()
+    private val azureAdV2Mock = AzureAdV2Mock()
+    private val tilgangskontrollMock = VeilederTilgangskontrollMock()
+    private val pdlMock = PdlMock()
 
     val externalApplicationMockMap = hashMapOf(
         azureAdV2Mock.name to azureAdV2Mock.server,
-        tilgangskontrollMock.name to tilgangskontrollMock.server
+        tilgangskontrollMock.name to tilgangskontrollMock.server,
+        pdlMock.name to pdlMock.server,
     )
 
     val environment = testEnvironment(
         kafkaBootstrapServers = embeddedEnvironment.brokersURL,
         azureTokenEndpoint = azureAdV2Mock.url,
-        syfotilgangskontrollUrl = tilgangskontrollMock.url
+        syfotilgangskontrollUrl = tilgangskontrollMock.url,
+        pdlUrl = pdlMock.url,
     )
 
     val wellKnownInternADV2Mock = wellKnownInternADV2Mock()

--- a/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestApiModule.kt
@@ -2,15 +2,22 @@ package no.nav.syfo.testutil
 
 import io.ktor.server.application.*
 import no.nav.syfo.api.apiModule
+import no.nav.syfo.client.azuread.v2.AzureAdV2Client
 import no.nav.syfo.personoppgavehendelse.PersonoppgavehendelseProducer
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
     personoppgavehendelseProducer: PersonoppgavehendelseProducer,
 ) {
+    val azureAdV2Client = AzureAdV2Client(
+        azureAppClientId = externalMockEnvironment.environment.azureAppClientId,
+        azureAppClientSecret = externalMockEnvironment.environment.azureAppClientSecret,
+        azureTokenEndpoint = externalMockEnvironment.environment.azureTokenEndpoint,
+    )
 
     apiModule(
         applicationState = externalMockEnvironment.applicationState,
+        azureAdV2Client = azureAdV2Client,
         database = externalMockEnvironment.database,
         environment = externalMockEnvironment.environment,
         personoppgavehendelseProducer = personoppgavehendelseProducer,

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -8,6 +8,7 @@ fun testEnvironment(
     kafkaBootstrapServers: String,
     azureTokenEndpoint: String = "azureTokenEndpoint",
     syfotilgangskontrollUrl: String = "tilgangskontroll",
+    pdlUrl: String? = null,
 ) = Environment(
     applicationThreads = 1,
     applicationName = "ispersonoppgave",
@@ -20,6 +21,8 @@ fun testEnvironment(
     ispersonoppgaveDbName = "ispersonoppgave_dev",
     ispersonoppgaveDbUsername = "username",
     ispersonoppgaveDbPassword = "password",
+    pdlClientId = "pdlClientId",
+    pdlUrl = pdlUrl ?: "http://pdl",
     serviceuserUsername = "",
     serviceuserPassword = "",
     syfotilgangskontrollClientId = syfotilgangskontrollUrl,

--- a/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/UserConstants.kt
@@ -6,6 +6,8 @@ import no.nav.syfo.domain.Virksomhetsnummer
 object UserConstants {
     val ARBEIDSTAKER_FNR = PersonIdent("12345678912")
     val ARBEIDSTAKER_2_FNR = PersonIdent(ARBEIDSTAKER_FNR.value.replace("2", "1"))
+    val ARBEIDSTAKER_3_FNR = PersonIdent("12345678913")
+    val FEILENDE_FNR = PersonIdent("12345670000")
     val VIRKSOMHETSNUMMER = Virksomhetsnummer("123456789")
     const val NAV_ENHET = "0330"
     const val VEILEDER_IDENT = "Z999999"

--- a/src/test/kotlin/no/nav/syfo/testutil/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/mock/PdlMock.kt
@@ -1,0 +1,74 @@
+package no.nav.syfo.testutil.mock
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.api.installContentNegotiation
+import no.nav.syfo.client.pdl.domain.*
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.testutil.UserConstants
+import no.nav.syfo.testutil.getRandomPort
+
+fun PersonIdent.toHistoricalPersonIdent(): PersonIdent {
+    val firstDigit = this.value[0].digitToInt()
+    val newDigit = firstDigit + 4
+    val dNummer = this.value.replace(
+        firstDigit.toString(),
+        newDigit.toString(),
+    )
+    return PersonIdent(dNummer)
+}
+
+fun generatePdlIdenterResponse(
+    personIdentNumber: PersonIdent,
+) = PdlIdenterResponse(
+    data = PdlHentIdenter(
+        hentIdenter = PdlIdenter(
+            identer = listOf(
+                PdlIdent(
+                    ident = personIdentNumber.value,
+                    historisk = false,
+                    gruppe = IdentType.FOLKEREGISTERIDENT,
+                ),
+                PdlIdent(
+                    ident = personIdentNumber.toHistoricalPersonIdent().value,
+                    historisk = true,
+                    gruppe = IdentType.FOLKEREGISTERIDENT,
+                ),
+            ),
+        ),
+    ),
+    errors = null,
+)
+
+class PdlMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+    val name = "pdl"
+    val server = embeddedServer(
+        factory = Netty,
+        port = port
+    ) {
+        installContentNegotiation()
+        routing {
+            post {
+                val pdlRequest = call.receive<PdlHentIdenterRequest>()
+                when (val personIdentNumber = PersonIdent(pdlRequest.variables.ident)) {
+                    UserConstants.ARBEIDSTAKER_3_FNR -> {
+                        call.respond(generatePdlIdenterResponse(PersonIdent("11111111111")))
+                    }
+                    UserConstants.FEILENDE_FNR -> {
+                        call.respond(HttpStatusCode.InternalServerError)
+                    }
+                    else -> {
+                        call.respond(generatePdlIdenterResponse(personIdentNumber))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dessverre trenger vi å legge til avhengighet til pdl-apiet for å dobbeltsjekke om identhendelser har blitt oppdatert i PDL når de kommer inn via topicen. Ettersom det ikke var støtte for dette allerede i appen, må hele riggen for dette legges til. Håper jeg har fått med alt!