### PR TITLE
Behandle all ubehandlet personoppgave for personident and type

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personoppgave/GetPersonOppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/GetPersonOppgaveQueries.kt
@@ -1,7 +1,10 @@
 package no.nav.syfo.personoppgave
 
+import no.nav.syfo.database.DatabaseInterface
 import no.nav.syfo.database.toList
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.personoppgave.domain.PPersonOppgave
+import no.nav.syfo.personoppgave.domain.PersonOppgaveType
 import java.sql.Connection
 
 const val queryGetPersonOppgaverByPublish =
@@ -18,6 +21,26 @@ fun Connection.getPersonOppgaverByPublish(publish: Boolean): List<PPersonOppgave
         it.setBoolean(1, publish)
         it.executeQuery().toList {
             toPPersonOppgave()
+        }
+    }
+}
+
+const val queryGetUbehandledePersonOppgaver =
+    """
+    SELECT *
+    FROM PERSON_OPPGAVE
+    WHERE fnr = ?
+      AND type = ?
+      AND behandlet_tidspunkt IS NULL
+      AND behandlet_veileder_ident IS NULL
+    """
+
+fun DatabaseInterface.getUbehandledePersonOppgaver(personIdent: PersonIdent, personOppgaveType: PersonOppgaveType): List<PPersonOppgave> {
+    return connection.use { connection ->
+        connection.prepareStatement(queryGetUbehandledePersonOppgaver).use {
+            it.setString(1, personIdent.value)
+            it.setString(2, personOppgaveType.name)
+            it.executeQuery().toList { toPPersonOppgave() }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/personoppgave/api/v2/BehandlePersonoppgaveRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/api/v2/BehandlePersonoppgaveRequestDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.personoppgave.api.v2
+
+import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+
+data class BehandlePersonoppgaveRequestDTO(
+    val personIdent: String,
+    val personOppgaveType: PersonOppgaveType,
+)

--- a/src/test/kotlin/no/nav/syfo/testutil/personoppgaveGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/personoppgaveGenerator.kt
@@ -5,13 +5,15 @@ import no.nav.syfo.personoppgave.domain.PersonOppgaveType
 import java.time.LocalDateTime
 import java.util.*
 
-fun generatePersonoppgave() = PersonOppgave(
+fun generatePersonoppgave(
+    type: PersonOppgaveType = PersonOppgaveType.DIALOGMOTESVAR
+) = PersonOppgave(
     id = 1,
     uuid = UUID.randomUUID(),
     referanseUuid = UUID.randomUUID(),
     personIdent = UserConstants.ARBEIDSTAKER_FNR,
     virksomhetsnummer = null,
-    type = PersonOppgaveType.DIALOGMOTESVAR,
+    type = type,
     oversikthendelseTidspunkt = null,
     behandletTidspunkt = null,
     behandletVeilederIdent = null,


### PR DESCRIPTION
Tanken er å sende inn personident og type. Anders kom også med et innspill om at vi kunne sende en liste med uuider fra frontend, og på den måten blir et kanskje mer likt det andre endepunktet (og vi bruker uuid).

Vet ikke om det å sjekke på personident og type går ut over ytelsen med de indeksene vi har i dag?