### PR TITLE
Automatically behandle oppgave for ubesvart melding if svar received

### DIFF
--- a/src/main/kotlin/no/nav/syfo/behandlerdialog/kafka/KafkaUbesvartMelding.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlerdialog/kafka/KafkaUbesvartMelding.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.kafka.*
 import no.nav.syfo.metric.COUNT_PERSONOPPGAVEHENDELSE_UBESVART_MELDING_MOTTATT
 import no.nav.syfo.personoppgave.createPersonOppgave
 import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.getPersonOppgaveByReferanseUuid
 import org.apache.kafka.clients.consumer.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -78,10 +79,13 @@ class KafkaUbesvartMelding(private val database: DatabaseInterface) : KafkaConsu
         connection: Connection,
     ) {
         log.info("Received ubesvart melding with uuid: ${melding.referanseUuid}")
-        connection.createPersonOppgave(
-            melding = melding,
-            personOppgaveType = PersonOppgaveType.BEHANDLERDIALOG_MELDING_UBESVART,
-        )
+        val existingOppgave = connection.getPersonOppgaveByReferanseUuid(melding.referanseUuid)
+        if (existingOppgave == null) {
+            connection.createPersonOppgave(
+                melding = melding,
+                personOppgaveType = PersonOppgaveType.BEHANDLERDIALOG_MELDING_UBESVART,
+            )
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/util/Constants.kt
+++ b/src/main/kotlin/no/nav/syfo/util/Constants.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.util
+
+object Constants {
+    const val SYSTEM_VEILEDER_IDENT = "X000000"
+}

--- a/src/main/resources/db/migration/V5_2__alter_constraint_referanse_uuid.sql
+++ b/src/main/resources/db/migration/V5_2__alter_constraint_referanse_uuid.sql
@@ -1,0 +1,4 @@
+ALTER TABLE person_oppgave
+DROP CONSTRAINT person_oppgave_referanse_uuid_key;
+
+CREATE INDEX ix_person_oppgave_referase_uuid ON person_oppgave(referanse_uuid);

--- a/src/test/kotlin/no/nav/syfo/behandlerdialog/MeldingFraBehandlerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlerdialog/MeldingFraBehandlerSpek.kt
@@ -5,11 +5,17 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.behandlerdialog.domain.KMeldingDTO
 import no.nav.syfo.behandlerdialog.kafka.KafkaMeldingFraBehandler
+import no.nav.syfo.behandlerdialog.kafka.KafkaUbesvartMelding
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.domain.toPersonOppgave
 import no.nav.syfo.personoppgave.getPersonOppgaveByReferanseUuid
+import no.nav.syfo.personoppgave.getPersonOppgaveList
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.mock.mockReceiveMeldingDTO
+import no.nav.syfo.util.Constants
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
 import org.apache.kafka.clients.consumer.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -23,11 +29,11 @@ class MeldingFraBehandlerSpek : Spek({
 
             val externalMockEnvironment = ExternalMockEnvironment()
             val database = externalMockEnvironment.database
-            val kafkaMeldingFraBehandlerConsumer = mockk<KafkaConsumer<String, KMeldingDTO>>()
+            val kafkaMeldingConsumer = mockk<KafkaConsumer<String, KMeldingDTO>>()
             val kafkaMeldingFraBehandler = KafkaMeldingFraBehandler(database = database)
 
             beforeEachTest {
-                every { kafkaMeldingFraBehandlerConsumer.commitSync() } returns Unit
+                every { kafkaMeldingConsumer.commitSync() } returns Unit
             }
 
             afterEachTest {
@@ -47,11 +53,11 @@ class MeldingFraBehandlerSpek : Spek({
                 val kMeldingFraBehandler = generateKMeldingDTO(referanseUuid)
                 mockReceiveMeldingDTO(
                     kMeldingDTO = kMeldingFraBehandler,
-                    kafkaConsumer = kafkaMeldingFraBehandlerConsumer,
+                    kafkaConsumer = kafkaMeldingConsumer,
                 )
 
                 kafkaMeldingFraBehandler.pollAndProcessRecords(
-                    kafkaConsumer = kafkaMeldingFraBehandlerConsumer,
+                    kafkaConsumer = kafkaMeldingConsumer,
                 )
 
                 val pPersonOppgave = database.connection.getPersonOppgaveByReferanseUuid(
@@ -59,6 +65,36 @@ class MeldingFraBehandlerSpek : Spek({
                 )
                 pPersonOppgave?.publish shouldBeEqualTo true
                 pPersonOppgave?.type shouldBeEqualTo PersonOppgaveType.BEHANDLERDIALOG_SVAR.name
+            }
+
+            it("behandler ubesvart melding if svar received on same melding") {
+                val kafkaUbesvartMelding = KafkaUbesvartMelding(database)
+                val referanseUuid = UUID.randomUUID()
+                val kUbesvartMeldingDTO = generateKMeldingDTO(referanseUuid)
+                val kMeldingFraBehandlerDTO = generateKMeldingDTO(referanseUuid)
+
+                mockReceiveMeldingDTO(
+                    kMeldingDTO = kUbesvartMeldingDTO,
+                    kafkaConsumer = kafkaMeldingConsumer,
+                )
+                kafkaUbesvartMelding.pollAndProcessRecords(kafkaMeldingConsumer)
+                mockReceiveMeldingDTO(
+                    kMeldingDTO = kMeldingFraBehandlerDTO,
+                    kafkaConsumer = kafkaMeldingConsumer,
+                )
+                kafkaMeldingFraBehandler.pollAndProcessRecords(kafkaMeldingConsumer)
+
+                val personoppgaveList = database.getPersonOppgaveList(
+                    personIdent = PersonIdent(kUbesvartMeldingDTO.personIdent),
+                ).map { it.toPersonOppgave() }
+                personoppgaveList.size shouldBeEqualTo 2
+                val personoppgaveUbesvart = personoppgaveList.first { it.type == PersonOppgaveType.BEHANDLERDIALOG_MELDING_UBESVART }
+                val personoppgaveSvar = personoppgaveList.first { it.type == PersonOppgaveType.BEHANDLERDIALOG_SVAR }
+                personoppgaveUbesvart.behandletTidspunkt shouldNotBeEqualTo null
+                personoppgaveUbesvart.behandletVeilederIdent shouldBeEqualTo Constants.SYSTEM_VEILEDER_IDENT
+                personoppgaveUbesvart.publish shouldBeEqualTo true
+                personoppgaveSvar.behandletTidspunkt shouldBeEqualTo null
+                personoppgaveSvar.publish shouldBeEqualTo true
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/behandlerdialog/UbesvartMeldingSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/behandlerdialog/UbesvartMeldingSpek.kt
@@ -4,9 +4,13 @@ import io.ktor.server.testing.*
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.syfo.behandlerdialog.domain.KMeldingDTO
+import no.nav.syfo.behandlerdialog.kafka.KafkaMeldingFraBehandler
 import no.nav.syfo.behandlerdialog.kafka.KafkaUbesvartMelding
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.domain.toPersonOppgave
 import no.nav.syfo.personoppgave.getPersonOppgaveByReferanseUuid
+import no.nav.syfo.personoppgave.getPersonOppgaveList
 import no.nav.syfo.testutil.*
 import no.nav.syfo.testutil.mock.mockReceiveMeldingDTO
 import org.amshove.kluent.shouldBeEqualTo
@@ -23,11 +27,11 @@ class UbesvartMeldingSpek : Spek({
 
             val externalMockEnvironment = ExternalMockEnvironment()
             val database = externalMockEnvironment.database
-            val kafkaUbesvartMeldingConsumer = mockk<KafkaConsumer<String, KMeldingDTO>>()
+            val kafkaMeldingConsumer = mockk<KafkaConsumer<String, KMeldingDTO>>()
             val kafkaUbesvartMelding = KafkaUbesvartMelding(database)
 
             beforeEachTest {
-                every { kafkaUbesvartMeldingConsumer.commitSync() } returns Unit
+                every { kafkaMeldingConsumer.commitSync() } returns Unit
             }
 
             afterEachTest {
@@ -47,11 +51,11 @@ class UbesvartMeldingSpek : Spek({
                 val kMeldingDTO = generateKMeldingDTO(referanseUuid)
                 mockReceiveMeldingDTO(
                     kMeldingDTO = kMeldingDTO,
-                    kafkaConsumer = kafkaUbesvartMeldingConsumer,
+                    kafkaConsumer = kafkaMeldingConsumer,
                 )
 
                 kafkaUbesvartMelding.pollAndProcessRecords(
-                    kafkaConsumer = kafkaUbesvartMeldingConsumer,
+                    kafkaConsumer = kafkaMeldingConsumer,
                 )
 
                 val pPersonOppgave = database.connection.getPersonOppgaveByReferanseUuid(
@@ -59,6 +63,32 @@ class UbesvartMeldingSpek : Spek({
                 )
                 pPersonOppgave?.publish shouldBeEqualTo true
                 pPersonOppgave?.type shouldBeEqualTo PersonOppgaveType.BEHANDLERDIALOG_MELDING_UBESVART.name
+            }
+
+            it("creates no new ubesvart oppgave if already received svar for the same melding") {
+                val kafkaMeldingFraBehandler = KafkaMeldingFraBehandler(database)
+                val referanseUuid = UUID.randomUUID()
+                val kMeldingFraBehandlerDTO = generateKMeldingDTO(referanseUuid)
+                val kUbesvartMeldingDTO = generateKMeldingDTO(referanseUuid)
+
+                mockReceiveMeldingDTO(
+                    kMeldingDTO = kMeldingFraBehandlerDTO,
+                    kafkaConsumer = kafkaMeldingConsumer,
+                )
+                kafkaMeldingFraBehandler.pollAndProcessRecords(kafkaMeldingConsumer)
+                mockReceiveMeldingDTO(
+                    kMeldingDTO = kUbesvartMeldingDTO,
+                    kafkaConsumer = kafkaMeldingConsumer,
+                )
+                kafkaUbesvartMelding.pollAndProcessRecords(kafkaMeldingConsumer)
+
+                val personoppgaveList = database.getPersonOppgaveList(
+                    personIdent = PersonIdent(kUbesvartMeldingDTO.personIdent),
+                ).map { it.toPersonOppgave() }
+                personoppgaveList.size shouldBeEqualTo 1
+                val personoppgaveMeldingFraBehandler = personoppgaveList.first()
+                personoppgaveMeldingFraBehandler.type shouldBeEqualTo PersonOppgaveType.BEHANDLERDIALOG_SVAR
+                personoppgaveMeldingFraBehandler.referanseUuid shouldBeEqualTo referanseUuid
             }
         }
     }


### PR DESCRIPTION
Vi har to typer oppgaver på meldinger i dag:
1. Svar fra behandler
2. Melding er ubesvart på 14 dager og behandler kan påminnes

Hovedfeature: Hvis det har blitt laget en oppgave om påminnelse, men det kommer inn et svar fra behandler før veileder har rukket å plukke oppgaven, vil den oppgaven nå automatisk behandles av ident `X000000`. Samtidig blir det laget en ny oppgave på at det er mottatt et svar. 

Robusthet: Samtidig er det lagt inn en sjekk på at man ikke oppretter en ubesvart-oppgave dersom det allerede foreligger en (svar)oppgave på samme melding fra før. Dette er for å håndtere at det kan være forsinkelser på den ene topicen og ikke den andre, som gjør at de kommer feil inn til oss.

NB: Ettersom vi opprettet `referanse_uuid` feltet i DBen med `unique`, så har vi til nå ikke tillatt flere oppgaver per `referanseUuid`. Dette gjør vi nå på melding, og derfor er den constrainten fjernet. Jeg og Anders _tror_ ikke det skal ha noen konsekvenser, men vi kan kverne litt på det alle mann! 