### PR TITLE
IS-1661: Add consumer for aktivitetskrav-vurdering topic

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -85,3 +85,5 @@ spec:
       value: "dev-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
+    - name: IS_AKTIVITETSKRAV_VURDERING_CONSUMER_ENABLED
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -85,3 +85,5 @@ spec:
       value: "prod-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.prod-fss-pub.nais.io/graphql"
+    - name: IS_AKTIVITETSKRAV_VURDERING_CONSUMER_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -39,7 +39,8 @@ data class Environment(
     val electorPath: String = getEnvVar("ELECTOR_PATH"),
 
     val outdatedDialogmotesvarCutoff: LocalDate = LocalDate.parse(getEnvVar("OUTDATED_DIALOGMOTESVAR_CUTOFF")),
-    val kakfaConsumerAktivitetskravExpiredVarselEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_CONSUMER_AKTIVITETSKRAV_EXPIRED_VARSEL").toBoolean()
+    val kakfaConsumerAktivitetskravExpiredVarselEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_CONSUMER_AKTIVITETSKRAV_EXPIRED_VARSEL").toBoolean(),
+    val isAktivitetskravVurderingConsumerEnabled: Boolean = getEnvVar("IS_AKTIVITETSKRAV_VURDERING_CONSUMER_ENABLED").toBoolean(),
 ) {
     fun jdbcUrl(): String {
         return "jdbc:postgresql://$ispersonoppgaveDbHost:$ispersonoppgaveDbPort/$ispersonoppgaveDbName"

--- a/src/main/kotlin/no/nav/syfo/KafkaModule.kt
+++ b/src/main/kotlin/no/nav/syfo/KafkaModule.kt
@@ -2,6 +2,7 @@ package no.nav.syfo
 
 import no.nav.syfo.aktivitetskrav.VurderStansService
 import no.nav.syfo.aktivitetskrav.kafka.launchKafkaTaskAktivitetskravExpiredVarsel
+import no.nav.syfo.aktivitetskrav.kafka.launchKafkaTaskAktivitetskravVurdering
 import no.nav.syfo.behandlerdialog.AvvistMeldingService
 import no.nav.syfo.behandlerdialog.MeldingFraBehandlerService
 import no.nav.syfo.behandlerdialog.UbesvartMeldingService
@@ -99,11 +100,19 @@ fun launchKafkaTasks(
         environment = environment,
         kafkaIdenthendelseConsumerService = kafkaIdenthendelseConsumerService,
     )
+
+    val vurderStansService = VurderStansService(
+        database = database,
+    )
     if (environment.kakfaConsumerAktivitetskravExpiredVarselEnabled) {
-        val vurderStansService = VurderStansService(
-            database = database,
-        )
         launchKafkaTaskAktivitetskravExpiredVarsel(
+            applicationState = applicationState,
+            environment = environment,
+            vurderStansService = vurderStansService,
+        )
+    }
+    if (environment.isAktivitetskravVurderingConsumerEnabled) {
+        launchKafkaTaskAktivitetskravVurdering(
             applicationState = applicationState,
             environment = environment,
             vurderStansService = vurderStansService,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/VurderStansService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/VurderStansService.kt
@@ -1,12 +1,17 @@
 package no.nav.syfo.aktivitetskrav
 
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
 import no.nav.syfo.aktivitetskrav.domain.ExpiredVarsel
 import no.nav.syfo.aktivitetskrav.domain.VarselType
 import no.nav.syfo.database.DatabaseInterface
 import no.nav.syfo.metric.COUNT_PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT
 import no.nav.syfo.personoppgave.createPersonOppgave
 import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.domain.behandleAndReadyForPublish
+import no.nav.syfo.personoppgave.domain.toPersonOppgaver
 import no.nav.syfo.personoppgave.getUbehandledePersonOppgaver
+import no.nav.syfo.personoppgave.updatePersonoppgaveSetBehandlet
+import no.nav.syfo.util.toLocalDateTimeOslo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -33,6 +38,30 @@ class VurderStansService(
                         log.info("Personoppgave already exists for uuid=${expiredVarsel.varselUuid} with type ${expiredVarsel.varselType}")
                     }
                     COUNT_PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT.increment()
+                }
+            }
+            connection.commit()
+        }
+    }
+
+    fun processAktivitetskravVurdering(aktivitetskravVurderinger: List<AktivitetskravVurdering>) {
+        database.connection.use { connection ->
+            aktivitetskravVurderinger.forEach { vurdering ->
+                log.info("Received aktivitetskravVurdering with uuid=${vurdering.uuid} and status=${vurdering.status}")
+                val ubehandledeVurderStansOppgaver = connection.getUbehandledePersonOppgaver(
+                    personIdent = vurdering.personIdent,
+                    personOppgaveType = PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS,
+                ).toPersonOppgaver()
+                if (ubehandledeVurderStansOppgaver.size > 1) throw IllegalStateException("Cannot have more than one AKTIVITETSKRAV_VURDER_STANS oppgave per personident")
+
+                val vurderStansOppgave = ubehandledeVurderStansOppgaver.firstOrNull()
+                if (
+                    vurderStansOppgave != null &&
+                    vurdering.isFinalVurdering() &&
+                    vurderStansOppgave.opprettet < vurdering.sistVurdert.toLocalDateTimeOslo() // Teste NY og dato
+                ) {
+                    val behandletOppgave = vurderStansOppgave.behandleAndReadyForPublish(veilederIdent = vurdering.vurdertAv)
+                    connection.updatePersonoppgaveSetBehandlet(behandletOppgave)
                 }
             }
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/VurderStansService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/VurderStansService.kt
@@ -4,7 +4,8 @@ import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
 import no.nav.syfo.aktivitetskrav.domain.ExpiredVarsel
 import no.nav.syfo.aktivitetskrav.domain.VarselType
 import no.nav.syfo.database.DatabaseInterface
-import no.nav.syfo.metric.COUNT_PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT
+import no.nav.syfo.metric.COUNT_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT
+import no.nav.syfo.metric.COUNT_PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING
 import no.nav.syfo.personoppgave.createPersonOppgave
 import no.nav.syfo.personoppgave.domain.PersonOppgaveType
 import no.nav.syfo.personoppgave.domain.behandleAndReadyForPublish
@@ -34,10 +35,10 @@ class VurderStansService(
                             personOppgaveType = PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS,
                             publish = true, // cronjob will publish
                         )
+                        COUNT_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT.increment()
                     } else {
                         log.info("Personoppgave already exists for uuid=${expiredVarsel.varselUuid} with type ${expiredVarsel.varselType}")
                     }
-                    COUNT_PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT.increment()
                 }
             }
             connection.commit()
@@ -62,6 +63,7 @@ class VurderStansService(
                 ) {
                     val behandletOppgave = vurderStansOppgave.behandleAndReadyForPublish(veilederIdent = vurdering.vurdertAv)
                     connection.updatePersonoppgaveSetBehandlet(behandletOppgave)
+                    COUNT_PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING.increment()
                 }
             }
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.aktivitetskrav.domain
+
+import no.nav.syfo.domain.PersonIdent
+import java.time.OffsetDateTime
+import java.util.*
+
+data class AktivitetskravVurdering(
+    val uuid: UUID,
+    val personIdent: PersonIdent,
+    val createdAt: OffsetDateTime,
+    val status: AktivitetskravStatus,
+    val vurdertAv: String,
+    val sistVurdert: OffsetDateTime,
+) {
+    fun isFinalVurdering() = status in finalVurderinger
+}
+
+private val finalVurderinger = EnumSet.of(
+    AktivitetskravStatus.UNNTAK,
+    AktivitetskravStatus.OPPFYLT,
+    AktivitetskravStatus.IKKE_OPPFYLT,
+)
+
+enum class AktivitetskravStatus {
+    NY,
+    AVVENT,
+    UNNTAK,
+    OPPFYLT,
+    AUTOMATISK_OPPFYLT,
+    FORHANDSVARSEL,
+    STANS,
+    IKKE_OPPFYLT,
+    IKKE_AKTUELL,
+    LUKKET,
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.aktivitetskrav.domain
 
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.personoppgave.domain.PersonOppgave
+import no.nav.syfo.util.toLocalDateTimeOslo
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -13,12 +15,16 @@ data class AktivitetskravVurdering(
     val sistVurdert: OffsetDateTime,
 ) {
     fun isFinalVurdering() = status in finalVurderinger
+
+    infix fun happenedAfter(personOppgave: PersonOppgave) =
+        sistVurdert.toLocalDateTimeOslo().isAfter(personOppgave.opprettet)
 }
 
 private val finalVurderinger = EnumSet.of(
     AktivitetskravStatus.UNNTAK,
     AktivitetskravStatus.OPPFYLT,
     AktivitetskravStatus.IKKE_OPPFYLT,
+    AktivitetskravStatus.IKKE_AKTUELL,
 )
 
 enum class AktivitetskravStatus {

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumer.kt
@@ -1,0 +1,67 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.Environment
+import no.nav.syfo.aktivitetskrav.VurderStansService
+import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingConsumer.Companion.AKTIVITETSKRAV_VURDERING_TOPIC
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.kafka.KafkaConsumerService
+import no.nav.syfo.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.kafka.launchKafkaTask
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+fun launchKafkaTaskAktivitetskravVurdering(
+    applicationState: ApplicationState,
+    environment: Environment,
+    vurderStansService: VurderStansService,
+) {
+    val consumerProperties = kafkaAivenConsumerConfig<AktivitetskravVurderingDeserializer>(environment.kafka)
+    consumerProperties.apply {
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+    }
+    val aktivitetskravVurderingConsumer = AktivitetskravExpiredVarselConsumer(
+        vurderStansService = vurderStansService,
+    )
+    launchKafkaTask(
+        applicationState = applicationState,
+        kafkaConsumerService = aktivitetskravVurderingConsumer,
+        consumerProperties = consumerProperties,
+        topic = AKTIVITETSKRAV_VURDERING_TOPIC,
+    )
+}
+
+class AktivitetskravVurderingConsumer(
+    private val vurderStansService: VurderStansService,
+) : KafkaConsumerService<KafkaAktivitetskravVurdering> {
+
+    override val pollDurationInMillis: Long = 1000
+
+    override fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaAktivitetskravVurdering>) {
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            log.info("KafkaAktivitetskravVurderingConsumer trace: Received ${records.count()} records")
+            processRecords(records = records)
+            kafkaConsumer.commitSync()
+        }
+    }
+
+    private fun processRecords(records: ConsumerRecords<String, KafkaAktivitetskravVurdering>) {
+        val validRecords = records.requireNoNulls()
+        vurderStansService.processAktivitetskravVurdering(
+            aktivitetskravVurderinger = validRecords
+                .map { it.value() }
+                .filter { it.sistVurdert != null && it.updatedBy != null }
+                .map { it.toAktivitetskravVurdering() },
+        )
+    }
+
+    companion object {
+        const val AKTIVITETSKRAV_VURDERING_TOPIC = "teamsykefravr.aktivitetskrav-vurdering"
+        val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumer.kt
@@ -24,7 +24,7 @@ fun launchKafkaTaskAktivitetskravVurdering(
     consumerProperties.apply {
         this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
     }
-    val aktivitetskravVurderingConsumer = AktivitetskravExpiredVarselConsumer(
+    val aktivitetskravVurderingConsumer = AktivitetskravVurderingConsumer(
         vurderStansService = vurderStansService,
     )
     launchKafkaTask(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingDeserializer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingDeserializer.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Deserializer
+
+class AktivitetskravVurderingDeserializer : Deserializer<KafkaAktivitetskravVurdering> {
+    private val mapper = configuredJacksonMapper()
+    override fun deserialize(topic: String, data: ByteArray): KafkaAktivitetskravVurdering =
+        mapper.readValue(data, KafkaAktivitetskravVurdering::class.java)
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.aktivitetskrav.kafka.domain
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
+import no.nav.syfo.domain.PersonIdent
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+
+data class KafkaAktivitetskravVurdering(
+    val uuid: String,
+    val personIdent: String,
+    val createdAt: OffsetDateTime,
+    val status: String,
+    val beskrivelse: String?,
+    val arsaker: List<String>,
+    val stoppunktAt: LocalDate,
+    val updatedBy: String?,
+    val sistVurdert: OffsetDateTime?,
+    val frist: LocalDate?,
+) {
+    fun toAktivitetskravVurdering() = AktivitetskravVurdering(
+        uuid = UUID.fromString(uuid),
+        personIdent = PersonIdent(personIdent),
+        createdAt = createdAt,
+        status = AktivitetskravStatus.valueOf(status),
+        vurdertAv = updatedBy!!,
+        sistVurdert = sistVurdert!!,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -73,11 +73,11 @@ val COUNT_PERSONOPPGAVEHENDELSE_AVVIST_MELDING_MOTTATT: Counter =
         .description("Counts the number of personoppgavehendelse with PersonoppgavehendelseType BEHANDLERDIALOG_MELDING_AVVIST_MOTTATT created from a KMeldingDTO")
         .register(METRICS_REGISTRY)
 
-const val AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT =
-    "${METRICS_NS}_aktivitetskrav_expired_varsel_mottatt_count"
-val COUNT_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT: Counter =
-    Counter.builder(AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT)
-        .description("Counts the number of aktivitetkrav expired varsel created ")
+const val AKTIVITETSKRAV_EXPIRED_VARSEL_PERSON_OPPGAVE_CREATED =
+    "${METRICS_NS}_aktivitetskrav_expired_varsel_person_oppgave_created_count"
+val COUNT_AKTIVITETSKRAV_EXPIRED_VARSEL_PERSON_OPPGAVE_CREATED: Counter =
+    Counter.builder(AKTIVITETSKRAV_EXPIRED_VARSEL_PERSON_OPPGAVE_CREATED)
+        .description("Counts the number of personoppgaver created from aktivitetkrav expired varsel")
         .register(METRICS_REGISTRY)
 
 const val PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING =

--- a/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
+++ b/src/main/kotlin/no/nav/syfo/metric/Metrics.kt
@@ -73,9 +73,16 @@ val COUNT_PERSONOPPGAVEHENDELSE_AVVIST_MELDING_MOTTATT: Counter =
         .description("Counts the number of personoppgavehendelse with PersonoppgavehendelseType BEHANDLERDIALOG_MELDING_AVVIST_MOTTATT created from a KMeldingDTO")
         .register(METRICS_REGISTRY)
 
-const val PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT =
-    "${METRICS_NS}_personoppgavehendelse_aktivitetskrav_expired_varsel_mottatt_count"
-val COUNT_PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT: Counter =
-    Counter.builder(PERSONOPPGAVEHENDELSE_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT)
-        .description("Counts the number of personoppgavehendelse with PersonoppgavehendelseType AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT created")
+const val AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT =
+    "${METRICS_NS}_aktivitetskrav_expired_varsel_mottatt_count"
+val COUNT_AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT: Counter =
+    Counter.builder(AKTIVITETSKRAV_EXPIRED_VARSEL_MOTTATT)
+        .description("Counts the number of aktivitetkrav expired varsel created ")
+        .register(METRICS_REGISTRY)
+
+const val PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING =
+    "${METRICS_NS}_aktivitetskrav_vurdering_mottatt_count"
+val COUNT_PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING: Counter =
+    Counter.builder(PERSONOPPGAVE_UPDATED_FROM_AKTIVITETSKRAV_VURDERING)
+        .description("Counts the number of personoppgaver updated from incoming aktivitetskrav vurderinger")
         .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingConsumerSpek.kt
@@ -1,0 +1,281 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import io.ktor.server.testing.*
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.syfo.aktivitetskrav.VurderStansService
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.personoppgave.domain.PersonOppgave
+import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.domain.behandle
+import no.nav.syfo.personoppgave.domain.toPersonOppgave
+import no.nav.syfo.personoppgave.getPersonOppgaver
+import no.nav.syfo.personoppgave.updatePersonoppgaveSetBehandlet
+import no.nav.syfo.testutil.ExternalMockEnvironment
+import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
+import no.nav.syfo.testutil.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.testutil.createPersonOppgave
+import no.nav.syfo.testutil.dropData
+import no.nav.syfo.testutil.generatePersonoppgave
+import no.nav.syfo.testutil.generators.generateKafkaAktivitetskravVurdering
+import no.nav.syfo.testutil.mock.mockPollConsumerRecords
+import org.amshove.kluent.*
+import org.amshove.kluent.internal.assertFailsWith
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.IllegalStateException
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.*
+
+class AktivitetskravVurderingConsumerSpek : Spek({
+    describe(AktivitetskravVurderingConsumer::class.java.simpleName) {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val topic = AktivitetskravVurderingConsumer.AKTIVITETSKRAV_VURDERING_TOPIC
+            val externalMockEnvironment = ExternalMockEnvironment()
+            val database = externalMockEnvironment.database
+            val kafkaConsumer = mockk<KafkaConsumer<String, KafkaAktivitetskravVurdering>>()
+            val vurderStansService = VurderStansService(
+                database = database,
+            )
+            val aktivitetskravVurderingConsumer = AktivitetskravVurderingConsumer(
+                vurderStansService = vurderStansService,
+            )
+
+            beforeEachTest {
+                every { kafkaConsumer.commitSync() } returns Unit
+            }
+
+            afterEachTest {
+                database.dropData()
+                clearMocks(kafkaConsumer)
+            }
+
+            describe("Consume aktivitetskravvurderinger") {
+                val vurderingUnntak = generateKafkaAktivitetskravVurdering()
+                val ubehandletVurderStansOppgave = generatePersonoppgave(
+                    personIdent = ARBEIDSTAKER_FNR,
+                    type = PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS,
+                    opprettet = LocalDateTime.now().minusDays(1),
+                    sistEndret = LocalDateTime.now().minusDays(1),
+                )
+                fun createOppgave(oppgave: PersonOppgave) {
+                    database.connection.use { connection ->
+                        connection.createPersonOppgave(oppgave)
+                        connection.commit()
+                    }
+                }
+
+                it("Will behandle existing vurder_stans oppgave when status is UNNTAK") {
+                    createOppgave(ubehandletVurderStansOppgave)
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingUnntak,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingUnntak.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingUnntak.personIdent
+                    personOppgave.publish shouldBeEqualTo true
+                    personOppgave.type shouldBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldNotBeEqualTo null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo vurderingUnntak.updatedBy
+                }
+
+                it("Will not behandle when no existing vurder-stans oppgave") {
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingUnntak,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val pPersonOppgaver = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingUnntak.personIdent),
+                    )
+                    pPersonOppgaver.size shouldBeEqualTo 0
+                }
+
+                it("Will not behandle when vurder-stans oppgave already behandlet") {
+                    val originalVeileder = VEILEDER_IDENT
+                    database.connection.use { connection ->
+                        connection.createPersonOppgave(ubehandletVurderStansOppgave)
+                        val behandletVurderStansOppgave = ubehandletVurderStansOppgave.behandle(originalVeileder)
+                        connection.updatePersonoppgaveSetBehandlet(behandletVurderStansOppgave)
+                        connection.commit()
+                    }
+                    val vurderingUnntakByOtherVeileder = vurderingUnntak.copy(updatedBy = "X000000")
+
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingUnntakByOtherVeileder,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingUnntakByOtherVeileder.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingUnntakByOtherVeileder.personIdent
+                    personOppgave.publish shouldBeEqualTo false
+                    personOppgave.type shouldBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldNotBe null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo originalVeileder
+                }
+
+                it("Will not behandle when status for vurdering is not a final state for aktivitetskrav") {
+                    createOppgave(ubehandletVurderStansOppgave)
+                    val vurderingAvvent = vurderingUnntak.copy(status = AktivitetskravStatus.AVVENT.name)
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingAvvent,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingAvvent.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingAvvent.personIdent
+                    personOppgave.publish shouldBeEqualTo false
+                    personOppgave.type shouldBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldBeEqualTo null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo null
+                }
+
+                it("Will not behandle when vurdering has neither sistVurdert nor updatedBy (eg. has status NY)") {
+                    createOppgave(ubehandletVurderStansOppgave)
+                    val vurderingNyUtenSistVurdert = vurderingUnntak.copy(
+                        status = AktivitetskravStatus.NY.name,
+                        sistVurdert = null,
+                        updatedBy = null,
+                    )
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingNyUtenSistVurdert,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingNyUtenSistVurdert.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingNyUtenSistVurdert.personIdent
+                    personOppgave.publish shouldBeEqualTo false
+                    personOppgave.type shouldBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldBeEqualTo null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo null
+                }
+
+                it("Will not behandle when vurdering is older than existing oppgave") {
+                    createOppgave(ubehandletVurderStansOppgave)
+                    val vurderingOlderThanOppgave = vurderingUnntak.copy(
+                        sistVurdert = OffsetDateTime.now().minusDays(1).minusMinutes(1),
+                    )
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingOlderThanOppgave,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingOlderThanOppgave.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingOlderThanOppgave.personIdent
+                    personOppgave.publish shouldBeEqualTo false
+                    personOppgave.type shouldBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldBeEqualTo null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo null
+                }
+
+                it("Will not behandle if existing oppgave is not vurder-stans") {
+                    val otherUbehandletPersonoppgave = ubehandletVurderStansOppgave.copy(type = PersonOppgaveType.BEHANDLERDIALOG_SVAR)
+                    createOppgave(otherUbehandletPersonoppgave)
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingUnntak,
+                        topic = topic,
+                    )
+
+                    aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                        kafkaConsumer = kafkaConsumer,
+                    )
+                    verify(exactly = 1) {
+                        kafkaConsumer.commitSync()
+                    }
+
+                    val personOppgave = database.connection.getPersonOppgaver(
+                        personIdent = PersonIdent(vurderingUnntak.personIdent),
+                    ).map { it.toPersonOppgave() }.first()
+                    personOppgave.personIdent.value shouldBeEqualTo vurderingUnntak.personIdent
+                    personOppgave.publish shouldBeEqualTo false
+                    personOppgave.type shouldNotBeEqualTo PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+                    personOppgave.behandletTidspunkt shouldBeEqualTo null
+                    personOppgave.behandletVeilederIdent shouldBeEqualTo null
+                }
+
+                it("Will throw error in consumer when more than one vurder-stans oppgave for person") {
+                    createOppgave(ubehandletVurderStansOppgave)
+                    createOppgave(
+                        ubehandletVurderStansOppgave.copy(
+                            uuid = UUID.randomUUID(),
+                            referanseUuid = UUID.randomUUID(),
+                        )
+                    )
+
+                    kafkaConsumer.mockPollConsumerRecords(
+                        recordValue = vurderingUnntak,
+                        topic = topic,
+                    )
+
+                    assertFailsWith(IllegalStateException::class) {
+                        aktivitetskravVurderingConsumer.pollAndProcessRecords(
+                            kafkaConsumer = kafkaConsumer,
+                        )
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurderingSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurderingSpek.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.aktivitetskrav.kafka.domain
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
+import no.nav.syfo.testutil.generators.generateKafkaAktivitetskravVurdering
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class KafkaAktivitetskravVurderingSpek : Spek({
+
+    val kafkaAktivitetskravVurdering = generateKafkaAktivitetskravVurdering()
+
+    describe(KafkaAktivitetskravVurdering::class.java.simpleName) {
+        it("Will map correctly to AktivitetskravVurdering") {
+            val aktivitetskravVurdering = kafkaAktivitetskravVurdering.toAktivitetskravVurdering()
+
+            aktivitetskravVurdering.personIdent.value shouldBeEqualTo kafkaAktivitetskravVurdering.personIdent
+            aktivitetskravVurdering.status.name shouldBeEqualTo kafkaAktivitetskravVurdering.status
+            aktivitetskravVurdering.uuid.toString() shouldBeEqualTo kafkaAktivitetskravVurdering.uuid
+            aktivitetskravVurdering.vurdertAv shouldBeEqualTo kafkaAktivitetskravVurdering.updatedBy
+            aktivitetskravVurdering.createdAt shouldBeEqualTo kafkaAktivitetskravVurdering.createdAt
+            aktivitetskravVurdering.sistVurdert shouldBeEqualTo kafkaAktivitetskravVurdering.sistVurdert
+        }
+
+        it("Will fail if updatedBy and sistVurdert are null when mapping to AktivitetskravVurdering") {
+            val kafkaAktivitetskravVurderingNy = kafkaAktivitetskravVurdering.copy(
+                status = AktivitetskravStatus.NY.name,
+                updatedBy = null,
+                sistVurdert = null,
+            )
+
+            assertFailsWith(NullPointerException::class) {
+                kafkaAktivitetskravVurderingNy.toAktivitetskravVurdering()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/personoppgavehendelse/cronjob/PublishOppgavehendelseCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/personoppgavehendelse/cronjob/PublishOppgavehendelseCronjobSpek.kt
@@ -1,0 +1,171 @@
+package no.nav.syfo.personoppgavehendelse.cronjob
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.personoppgave.domain.PersonOppgave
+import no.nav.syfo.personoppgave.domain.PersonOppgaveType
+import no.nav.syfo.personoppgave.updatePersonoppgaveSetBehandlet
+import no.nav.syfo.personoppgavehendelse.PersonoppgavehendelseProducer
+import no.nav.syfo.personoppgavehendelse.PublishPersonoppgavehendelseService
+import no.nav.syfo.personoppgavehendelse.domain.KPersonoppgavehendelse
+import no.nav.syfo.personoppgavehendelse.domain.PersonoppgavehendelseType
+import no.nav.syfo.testutil.*
+import org.amshove.kluent.*
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.Future
+
+class PublishOppgavehendelseCronjobSpek : Spek({
+    describe(PublishOppgavehendelseCronjob::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+            val externalMockEnvironment = ExternalMockEnvironment()
+            val database = externalMockEnvironment.database
+            val kafkaProducer = mockk<KafkaProducer<String, KPersonoppgavehendelse>>()
+
+            val personoppgaveHendelseProducer = PersonoppgavehendelseProducer(
+                producer = kafkaProducer,
+            )
+            val publishOppgavehendelseService = PublishPersonoppgavehendelseService(
+                database = database,
+                personoppgavehendelseProducer = personoppgaveHendelseProducer,
+            )
+
+            val publishOppgavehendelseCronjob = PublishOppgavehendelseCronjob(
+                publishOppgavehendelseService = publishOppgavehendelseService,
+            )
+
+            beforeEachTest {
+                clearMocks(kafkaProducer)
+                coEvery {
+                    kafkaProducer.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+                database.dropData()
+            }
+
+            val unpublishedUbehandletPersonoppgave = generatePersonoppgave(
+                personIdent = UserConstants.ARBEIDSTAKER_FNR,
+                type = PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS,
+                publish = true,
+            )
+
+            fun createPersonoppgaver(vararg oppgaver: PersonOppgave) {
+                database.connection.use {
+                    oppgaver.forEach { oppgave ->
+                        it.createPersonOppgave(oppgave)
+                    }
+                    it.commit()
+                }
+            }
+
+            it("Will publish unpublished personoppgave") {
+                createPersonoppgaver(unpublishedUbehandletPersonoppgave)
+
+                runBlocking {
+                    val result = publishOppgavehendelseCronjob.publishOppgavehendelserJob()
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 1
+                }
+
+                val kafkaRecordSlot = slot<ProducerRecord<String, KPersonoppgavehendelse>>()
+                verify(exactly = 1) {
+                    kafkaProducer.send(capture(kafkaRecordSlot))
+                }
+
+                val kafkaPersonoppgavehendelse = kafkaRecordSlot.captured.value()
+                kafkaPersonoppgavehendelse.personident shouldBeEqualTo unpublishedUbehandletPersonoppgave.personIdent.value
+                kafkaPersonoppgavehendelse.hendelsetype shouldBeEqualTo PersonoppgavehendelseType.AKTIVITETSKRAV_VURDER_STANS_MOTTATT.name
+            }
+
+            it("Will only publish newest unpublished personoppgave of same type") {
+                val unpublishedBehandletPersonoppgave = unpublishedUbehandletPersonoppgave.copy(
+                    uuid = UUID.randomUUID(),
+                    referanseUuid = UUID.randomUUID(),
+                    sistEndret = LocalDateTime.now().plusMinutes(1),
+                    behandletTidspunkt = LocalDateTime.now(),
+                    behandletVeilederIdent = UserConstants.VEILEDER_IDENT,
+                )
+                database.connection.use {
+                    it.createPersonOppgave(unpublishedUbehandletPersonoppgave)
+                    it.createPersonOppgave(unpublishedBehandletPersonoppgave)
+                    it.updatePersonoppgaveSetBehandlet(unpublishedBehandletPersonoppgave)
+                    it.commit()
+                }
+
+                runBlocking {
+                    val result = publishOppgavehendelseCronjob.publishOppgavehendelserJob()
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 2 // Her burde det bli 1, men siden publish()-metoden egentlig bare er en "maybe-publish" så teller den updated++ her uansett om det faktisk ble publisert
+                }
+
+                val kafkaRecordSlot = slot<ProducerRecord<String, KPersonoppgavehendelse>>()
+                verify(exactly = 1) {
+                    kafkaProducer.send(capture(kafkaRecordSlot))
+                }
+
+                val kafkaPersonoppgavehendelse = kafkaRecordSlot.captured.value()
+                kafkaPersonoppgavehendelse.personident shouldBeEqualTo unpublishedUbehandletPersonoppgave.personIdent.value
+                kafkaPersonoppgavehendelse.hendelsetype shouldBeEqualTo PersonoppgavehendelseType.AKTIVITETSKRAV_VURDER_STANS_BEHANDLET.name
+            }
+
+            it("Will not publish already published oppgave") {
+                val alreadyPublishedOppgave = unpublishedUbehandletPersonoppgave.copy(
+                    publishedAt = OffsetDateTime.now(),
+                    publish = false,
+                )
+                createPersonoppgaver(alreadyPublishedOppgave)
+
+                runBlocking {
+                    val result = publishOppgavehendelseCronjob.publishOppgavehendelserJob()
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 0
+                }
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+            }
+
+            it("Will not publish if no personoppgaver") {
+                runBlocking {
+                    val result = publishOppgavehendelseCronjob.publishOppgavehendelserJob()
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 0
+                }
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+            }
+
+            it("Will fail when publishing to topic throws error") {
+                createPersonoppgaver(unpublishedUbehandletPersonoppgave)
+                coEvery {
+                    kafkaProducer.send(any())
+                } coAnswers { throw Exception() }
+
+                runBlocking {
+                    val result = publishOppgavehendelseCronjob.publishOppgavehendelserJob()
+
+                    result.failed shouldBeEqualTo 1
+                    result.updated shouldBeEqualTo 0
+                }
+
+                verify(exactly = 1) {
+                    kafkaProducer.send(any())
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testutil/PersonoppgaveGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/PersonoppgaveGenerator.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.testutil
 
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.personoppgave.domain.PPersonOppgave
 import no.nav.syfo.personoppgave.domain.PersonOppgave
@@ -10,20 +11,26 @@ import java.util.*
 fun generatePersonoppgave(
     uuid: UUID = UUID.randomUUID(),
     referanseUuid: UUID = UUID.randomUUID(),
+    personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_FNR,
     type: PersonOppgaveType = PersonOppgaveType.DIALOGMOTESVAR,
     virksomhetsnummer: Virksomhetsnummer? = null,
+    behandletTidspunkt: LocalDateTime? = null,
+    behandletVeilederIdent: String? = null,
+    opprettet: LocalDateTime = LocalDateTime.now(),
+    sistEndret: LocalDateTime = LocalDateTime.now(),
+    publish: Boolean = false,
 ) = PersonOppgave(
     uuid = uuid,
     referanseUuid = referanseUuid,
-    personIdent = UserConstants.ARBEIDSTAKER_FNR,
+    personIdent = personIdent,
     virksomhetsnummer = virksomhetsnummer,
     type = type,
     oversikthendelseTidspunkt = null,
-    behandletTidspunkt = null,
-    behandletVeilederIdent = null,
-    opprettet = LocalDateTime.now(),
-    sistEndret = LocalDateTime.now(),
-    publish = false,
+    behandletTidspunkt = behandletTidspunkt,
+    behandletVeilederIdent = behandletVeilederIdent,
+    opprettet = opprettet,
+    sistEndret = sistEndret,
+    publish = publish,
     publishedAt = null,
 )
 

--- a/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestEnvironment.kt
@@ -36,6 +36,7 @@ fun testEnvironment(
     electorPath = "electorPath",
     outdatedDialogmotesvarCutoff = LocalDate.parse("2022-04-01"),
     kakfaConsumerAktivitetskravExpiredVarselEnabled = true,
+    isAktivitetskravVurderingConsumerEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/testutil/generators/KafkaAktivitetskravVurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generators/KafkaAktivitetskravVurderingGenerator.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.testutil.generators
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.testutil.UserConstants
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+fun generateKafkaAktivitetskravVurdering(
+    uuid: String = UUID.randomUUID().toString(),
+    personIdent: String = UserConstants.ARBEIDSTAKER_FNR.value,
+    status: String = AktivitetskravStatus.UNNTAK.name,
+    updatedBy: String? = UserConstants.VEILEDER_IDENT,
+    sistVurdert: OffsetDateTime? = OffsetDateTime.now(),
+) = KafkaAktivitetskravVurdering(
+    uuid = uuid,
+    personIdent = personIdent,
+    createdAt = OffsetDateTime.now(),
+    status = status,
+    beskrivelse = null,
+    arsaker = emptyList(),
+    stoppunktAt = LocalDate.now().plusDays(10),
+    updatedBy = updatedBy,
+    sistVurdert = sistVurdert,
+    frist = null,
+)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Consumer for aktivitetskrav-vurdering
- Utvidet vurderStansService med logikk for å behandle oppgaver basert på om statusen til aktivitetskravvurderingen er en "finaltilstand" (enten `UNNTAK,` `IKKE_OPPFYLT` eller `OPPFYLT)`
    - Dette blir deretter plukket opp av cronjobben som publiserer til `syfooversiktsrv`
- Renamet og flyttet litt på metrics, hva vi teller og når vi teller
- Skrevet tester for consumer, domeneobjekt og cronjobben
    - Var litt overrasket over at cronjobben ikke hadde en egen test, så den testen blir nok mer generell (og mye av funksjonaliteten testes sikkert også i testen for servicen/produceren mot Personhendelse-topicet)

Se øvrige kommentarer i PRen. Jeg tenkte også å lage en refactor-PR i kjølvannet av denne, som flytter litt filer inn i packages som ligner mer på det vi har rundt omkring.