### PR TITLE
IS-2248: Close dialogmotesvar-oppgave

### DIFF
--- a/src/main/resources/db/migration/V5_4__close_open_oppgave_that_have_finished_motestatus.sql
+++ b/src/main/resources/db/migration/V5_4__close_open_oppgave_that_have_finished_motestatus.sql
@@ -1,0 +1,6 @@
+UPDATE person_oppgave
+SET behandlet_tidspunkt = now(),
+    behandlet_veileder_ident = 'X000000',
+    publish = true,
+    published_at = null
+WHERE referanse_uuid = '8a14f206-3afe-4ab7-acb3-a0f880904c3b';


### PR DESCRIPTION
Her har det kommet svar fra behandler i 7. februar 2024, og innkallingen ble sendt 22. august 2022.
Vi hadde tydeligvis ikke lagret møtestatus for dette møtet, kanskje fordi det er for gammelt, så da ble det ikke fanget opp i koden som sjekker om møtet som svares på er ferdigstilt.
https://jira.adeo.no/browse/FAGSYSTEM-324078