### PR TITLE
IS-2334: Close dialogmotesvar-oppgave for avlyst møte

### DIFF
--- a/src/main/resources/db/migration/V5_5__close_open_motesvar_oppgave.sql
+++ b/src/main/resources/db/migration/V5_5__close_open_motesvar_oppgave.sql
@@ -1,0 +1,6 @@
+UPDATE person_oppgave
+SET behandlet_tidspunkt = now(),
+    behandlet_veileder_ident = 'X000000',
+    publish = true,
+    published_at = null
+WHERE referanse_uuid = '98848881-04a9-4a93-9053-2c825ac727dc';


### PR DESCRIPTION
Ref. https://jira.adeo.no/browse/FAGSYSTEM-327850

Vi har ikke lagret møtestatus=AVLYST for dette møtet i ispersonoppgave (mulig det er for gammelt?). Så møtesvar-oppgaven er fortsatt ubehandlet.