### PR TITLE
IS-2691: Count sykmelding oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/KafkaSykmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/KafkaSykmeldingConsumer.kt
@@ -75,6 +75,12 @@ class KafkaSykmeldingConsumer(
                             connection = connection,
                             receivedSykmeldingDTO = receivedSykmeldingDTO,
                         )
+                    } else if (!receivedSykmeldingDTO.sykmelding.tiltakNAV.isNullOrEmpty()) {
+                        COUNT_MOTTATT_SYKMELDING_TILTAK_NAV.increment()
+                    } else if (!receivedSykmeldingDTO.sykmelding.andreTiltak.isNullOrEmpty()) {
+                        COUNT_MOTTATT_SYKMELDING_TILTAK_ANDRE.increment()
+                    } else if (receivedSykmeldingDTO.sykmelding.utdypendeOpplysninger.isNotEmpty()) {
+                        COUNT_MOTTATT_SYKMELDING_UTDYPENDE.increment()
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/ReceivedSykmeldingDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/ReceivedSykmeldingDTO.kt
@@ -23,6 +23,7 @@ data class Sykmelding(
     val id: String,
     val msgId: String,
     val medisinskVurdering: MedisinskVurdering,
+    val utdypendeOpplysninger: Map<String, Map<String, SporsmalSvar>>,
     val tiltakNAV: String?,
     val andreTiltak: String?,
     val meldingTilNAV: MeldingTilNAV?,
@@ -74,3 +75,19 @@ data class AvsenderSystem(
     val navn: String,
     val versjon: String,
 )
+
+data class SporsmalSvar(
+    val sporsmal: String,
+    val svar: String,
+    val restriksjoner: List<SvarRestriksjon>
+)
+
+enum class SvarRestriksjon(
+    val codeValue: String,
+    val text: String,
+    val oid: String = "2.16.578.1.12.4.1.1.8134"
+) {
+    SKJERMET_FOR_ARBEIDSGIVER("A", "Informasjonen skal ikke vises arbeidsgiver"),
+    SKJERMET_FOR_PASIENT("P", "Informasjonen skal ikke vises pasient"),
+    SKJERMET_FOR_NAV("N", "Informasjonen skal ikke vises NAV")
+}

--- a/src/main/kotlin/no/nav/syfo/sykmelding/SykmeldingMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/SykmeldingMetrics.kt
@@ -5,6 +5,9 @@ import no.nav.syfo.metric.*
 
 const val MOTTATT_SYKMELDING = "${METRICS_NS}_mottatt_sykmelding_count"
 const val MOTTATT_SYKMELDING_CREATED_PERSONOPPGAVE = "${METRICS_NS}_mottatt_sykmelding_personoppgave_count"
+const val MOTTATT_SYKMELDING_TILTAK_NAV = "${METRICS_NS}_mottatt_sykmelding_tiltak_nav_count"
+const val MOTTATT_SYKMELDING_TILTAK_ANDRE = "${METRICS_NS}_mottatt_sykmelding_tiltak_andre_count"
+const val MOTTATT_SYKMELDING_UTDYPENDE = "${METRICS_NS}_mottatt_sykmelding_utdypende_count"
 
 val COUNT_MOTTATT_SYKMELDING: Counter = Counter
     .builder(MOTTATT_SYKMELDING)
@@ -14,4 +17,19 @@ val COUNT_MOTTATT_SYKMELDING: Counter = Counter
 val COUNT_MOTTATT_SYKMELDING_SUCCESS: Counter = Counter
     .builder(MOTTATT_SYKMELDING_CREATED_PERSONOPPGAVE)
     .description("Counts the number of received sykmelding that created personoppgave")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_TILTAK_NAV: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_TILTAK_NAV)
+    .description("Counts the number of received sykmelding with tiltak NAV")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_TILTAK_ANDRE: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_TILTAK_ANDRE)
+    .description("Counts the number of received sykmelding with tiltak andre")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_UTDYPENDE: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_UTDYPENDE)
+    .description("Counts the number of received sykmelding with utdypende opplysninger")
     .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/testutil/generators/KafkaSykmeldingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/generators/KafkaSykmeldingGenerator.kt
@@ -55,6 +55,7 @@ fun generateKafkaSykmelding(
         syketilfelleStartDato = LocalDate.now(),
         signaturDato = LocalDateTime.now(),
         navnFastlege = "",
+        utdypendeOpplysninger = emptyMap(),
         meldingTilNAV = meldingTilNAV,
         andreTiltak = "",
         meldingTilArbeidsgiver = "",


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Begynne med å telle opp hvor mange personoppgaver vi potensielt kan få med å generere fra flere felt enn i dag. 

I dag lager vi ca 300 - 400 personoppgaver per dag basert på innkommende sykmeldinger med bistandsbehov.