### PR TITLE
IS-2691: Count sykmelding utdypende oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/KafkaSykmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/KafkaSykmeldingConsumer.kt
@@ -81,6 +81,19 @@ class KafkaSykmeldingConsumer(
                         COUNT_MOTTATT_SYKMELDING_TILTAK_ANDRE.increment()
                     } else if (receivedSykmeldingDTO.sykmelding.utdypendeOpplysninger.isNotEmpty()) {
                         COUNT_MOTTATT_SYKMELDING_UTDYPENDE.increment()
+                        val utdypende = receivedSykmeldingDTO.sykmelding.utdypendeOpplysninger
+                        if (utdypende.containsKey("6.3")) {
+                            // ved 7 uker
+                            COUNT_MOTTATT_SYKMELDING_UTDYPENDE_63.increment()
+                        }
+                        if (utdypende.containsKey("6.4")) {
+                            // ved 17 uker
+                            COUNT_MOTTATT_SYKMELDING_UTDYPENDE_64.increment()
+                        }
+                        if (utdypende.containsKey("6.5")) {
+                            // ved 39 uker
+                            COUNT_MOTTATT_SYKMELDING_UTDYPENDE_65.increment()
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/sykmelding/SykmeldingMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/SykmeldingMetrics.kt
@@ -8,6 +8,9 @@ const val MOTTATT_SYKMELDING_CREATED_PERSONOPPGAVE = "${METRICS_NS}_mottatt_sykm
 const val MOTTATT_SYKMELDING_TILTAK_NAV = "${METRICS_NS}_mottatt_sykmelding_tiltak_nav_count"
 const val MOTTATT_SYKMELDING_TILTAK_ANDRE = "${METRICS_NS}_mottatt_sykmelding_tiltak_andre_count"
 const val MOTTATT_SYKMELDING_UTDYPENDE = "${METRICS_NS}_mottatt_sykmelding_utdypende_count"
+const val MOTTATT_SYKMELDING_UTDYPENDE_63 = "${METRICS_NS}_mottatt_sykmelding_utdypende_63_count"
+const val MOTTATT_SYKMELDING_UTDYPENDE_64 = "${METRICS_NS}_mottatt_sykmelding_utdypende_64_count"
+const val MOTTATT_SYKMELDING_UTDYPENDE_65 = "${METRICS_NS}_mottatt_sykmelding_utdypende_65_count"
 
 val COUNT_MOTTATT_SYKMELDING: Counter = Counter
     .builder(MOTTATT_SYKMELDING)
@@ -31,5 +34,20 @@ val COUNT_MOTTATT_SYKMELDING_TILTAK_ANDRE: Counter = Counter
 
 val COUNT_MOTTATT_SYKMELDING_UTDYPENDE: Counter = Counter
     .builder(MOTTATT_SYKMELDING_UTDYPENDE)
+    .description("Counts the number of received sykmelding with utdypende opplysninger")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_UTDYPENDE_63: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_UTDYPENDE_63)
+    .description("Counts the number of received sykmelding with utdypende opplysninger")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_UTDYPENDE_64: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_UTDYPENDE_64)
+    .description("Counts the number of received sykmelding with utdypende opplysninger")
+    .register(METRICS_REGISTRY)
+
+val COUNT_MOTTATT_SYKMELDING_UTDYPENDE_65: Counter = Counter
+    .builder(MOTTATT_SYKMELDING_UTDYPENDE_65)
     .description("Counts the number of received sykmelding with utdypende opplysninger")
     .register(METRICS_REGISTRY)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det kommer veldig mange sykmeldinger med utdypende opplysninger (mer enn 1000 per dag), så vi må telle mer spesifikt på feltene som er relatert til sykefraværsoppfølgingen.