### PR TITLE
Use READ_COMMITTED isolation level

### DIFF
--- a/src/main/kotlin/no/nav/syfo/personoppgave/infrastructure/database/Database.kt
+++ b/src/main/kotlin/no/nav/syfo/personoppgave/infrastructure/database/Database.kt
@@ -30,7 +30,7 @@ class Database(
             maximumPoolSize = databaseConfig.poolSize
             minimumIdle = 1
             isAutoCommit = false
-            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            transactionIsolation = "TRANSACTION_READ_COMMITTED"
             metricsTrackerFactory = PrometheusMetricsTrackerFactory()
             validate()
         }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Ser at vi får en del feil (og pod'er som krasjer) med 
`org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update`

Tror det er trygt å lempe litt på isolasjonsnivået i databasen slik vi har gjort i flere andre app'er.