### PR TITLE
IS: Update commons-library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.adarshr.gradle.testlogger.theme.ThemeType
 group = "no.nav.syfo"
 version = "1.0-SNAPSHOT"
 
-val isyfoBackendCommonVersion = "0.0.48"
+val isyfoBackendCommonVersion = "1.3.1"
 
 val confluentVersion = "8.3.0"
 val jacksonDataTypeVersion = "2.22.1"


### PR DESCRIPTION
For å få tilgang til den nyeste loggingen ved manglende tilgang, bumber vi til ny versjon som støtter dette

Avhenger av https://github.com/navikt/isyfo-backend-common/pull/31